### PR TITLE
Make dexie-cloud-addon modern build not block (vitejs use case)

### DIFF
--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -216,7 +216,12 @@ export class Dexie implements IDexie {
     this.use(observabilityMiddleware);
     this.use(cacheExistingValuesMiddleware);
 
-    this.vip = Object.create(this, {_vip: {value: true}}) as Dexie;
+    // vip is a Dexie instance used in db.on('ready') that don't block until db is ready.
+    const vipDexie = Object.create(this) as Dexie;
+    vipDexie._vip = true;
+    vipDexie.Table = createTableConstructor(vipDexie);
+    vipDexie._allTables = {}; // So that it has it's own tables that refers back to the vip instance.
+    this.vip = vipDexie;
 
     // Call each addon:
     addons.forEach(addon => addon(this));

--- a/src/classes/dexie/generate-middleware-stacks.ts
+++ b/src/classes/dexie/generate-middleware-stacks.ts
@@ -38,7 +38,7 @@ export function generateMiddlewareStacks({_novip: db}: Dexie, tmpTrans: IDBTrans
     if (db.core.schema.tables.some(tbl => tbl.name === tableName)) {
       table.core = db.core.table(tableName);
       if (db[tableName] instanceof db.Table) {
-          db[tableName].core = table.core;
+          db[tableName].core = db.vip[tableName].core = table.core;
       }
     }
   });

--- a/src/classes/version/schema-helpers.ts
+++ b/src/classes/version/schema-helpers.ts
@@ -24,10 +24,11 @@ export function setApiOnPlace(objs: Array<Dexie | Transaction>, tableNames: stri
         // Either the prop is not declared, or it is initialized to undefined, or is already a Table
         // on parent prototype prop but we need to set it as own prop (on the vip Dexie instance that derives from real instance)
         if (obj instanceof Transaction) {
-          // obj is a Transaction prototype (or prototype of a subclass to Transaction)
+          // obj is a Transaction instance or the db.Transaction.prototype
+          // (which prototypally derives from Transaction.prototype, see transaction-contructor.ts)
           // Make the API a getter that returns this.table(tableName)
           setProp(obj, tableName, {
-            get(this: Transaction | Dexie) { return this.table(tableName); },
+            get(this: Transaction) { return this.table(tableName); },
             set(value: any) {
               // Issue #1039
               // Let "this.schema = dbschema;" and other props in transaction constructor work even if there's a name collision with the table name.

--- a/src/classes/version/version-constructor.ts
+++ b/src/classes/version/version-constructor.ts
@@ -23,7 +23,6 @@ export function createVersionConstructor(db: Dexie) {
         version: versionNumber,
         storesSource: null,
         dbschema: {},
-        tables: {},
         contentUpgrade: null
       };
     });

--- a/src/classes/version/version.ts
+++ b/src/classes/version/version.ts
@@ -18,7 +18,6 @@ export class Version implements IVersion {
     version: number,
     storesSource: { [tableName: string]: string | null },
     dbschema: DbSchema,
-    tables: {},
     contentUpgrade: Function | null
   }
 
@@ -38,7 +37,7 @@ export class Version implements IVersion {
   }
 
   stores(stores: { [key: string]: string | null; }): IVersion {
-    const db = this.db;
+    const db = this.db._novip;
     this._cfg.storesSource = this._cfg.storesSource ?
       extend(this._cfg.storesSource, stores) :
       stores;
@@ -55,8 +54,8 @@ export class Version implements IVersion {
     // Update the latest schema to this version
     db._dbSchema = dbschema;
     // Update APIs
-    removeTablesApi(db, [db._allTables, db, db.Transaction.prototype]);
-    setApiOnPlace(db, [db._allTables, db, db.Transaction.prototype, this._cfg.tables], keys(dbschema), dbschema);
+    removeTablesApi([db, db.vip, db.Transaction.prototype]);
+    setApiOnPlace([db, db.vip, db.Transaction.prototype], keys(dbschema), dbschema);
     db._storeNames = keys(dbschema);
     return this;
   }

--- a/src/public/types/dexie.d.ts
+++ b/src/public/types/dexie.d.ts
@@ -26,6 +26,7 @@ export interface Dexie {
   readonly name: string;
   readonly tables: Table[];
   readonly verno: number;
+  /** The 'vip' instance - passed to db.on('ready') and allows usage before db.on('ready') completes. */
   readonly vip: Dexie;
 
   readonly _allTables: { [name: string]: Table<any, IndexableType> };


### PR DESCRIPTION
Make sure db calls during db.on('ready') doesn't block when using a modern build where async/await aren't transpiled and we therefore need to rely on the vip flag property (db._vip) instead of only relying on the scoped vip flag (PSD.vip).

Resolves #1484
