### PR TITLE
replace old repo URL to new one (dexie/Dexie.js)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ HOW TO CONTRIBUTE
 We appreciate contributions in forms of:
 
 * issues
-* help answering questions in [issues](https://github.com/dfahlander/Dexie.js/issues) and on [stackoverflow](https://stackexchange.com/filters/233583/dexie-stackoverflow)
+* help answering questions in [issues](https://github.com/dexie/Dexie.js/issues) and on [stackoverflow](https://stackexchange.com/filters/233583/dexie-stackoverflow)
 * fixing bugs via pull-requests
 * developing addons or other [derived work](https://dexie.org/docs/DerivedWork)
 * promoting Dexie.js

--- a/addons/Dexie.Observable/README.md
+++ b/addons/Dexie.Observable/README.md
@@ -41,7 +41,7 @@ db.version(2).stores({}); // No need to add / remove tables. This is just to all
 
 ### Source
 
-[Dexie.Observable.js](https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Observable/src/Dexie.Observable.js)
+[Dexie.Observable.js](https://github.com/dexie/Dexie.js/blob/master/addons/Dexie.Observable/src/Dexie.Observable.js)
 
 ### Description
 

--- a/addons/Dexie.Observable/dist/README.md
+++ b/addons/Dexie.Observable/dist/README.md
@@ -1,6 +1,6 @@
 ## Can't find dexie-observable.js?
 Transpiled code (dist version) IS ONLY checked in to
-the [releases](https://github.com/dfahlander/Dexie.js/tree/releases/addons/Dexie.Observable/dist)
+the [releases](https://github.com/dexie/Dexie.js/tree/releases/addons/Dexie.Observable/dist)
 branch.
 
 ## Download

--- a/addons/Dexie.Observable/package.json
+++ b/addons/Dexie.Observable/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfahlander/Dexie.js.git"
+    "url": "https://github.com/dexie/Dexie.js.git"
   },
   "keywords": [
     "indexeddb",
@@ -31,7 +31,7 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/dfahlander/Dexie.js/issues"
+    "url": "https://github.com/dexie/Dexie.js/issues"
   },
   "scripts": {
     "build": "just-build",

--- a/addons/Dexie.Observable/src/Dexie.Observable.d.ts
+++ b/addons/Dexie.Observable/src/Dexie.Observable.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for dexie-observable v{version}
-// Project: https://github.com/dfahlander/Dexie.js/tree/master/addons/Dexie.Observable
+// Project: https://github.com/dexie/Dexie.js/tree/master/addons/Dexie.Observable
 // Definitions by: David Fahlander <http://github.com/dfahlander>
 
 import Dexie, { DexieEventSet } from 'dexie';

--- a/addons/Dexie.Observable/test/unit/tests-observable-misc.js
+++ b/addons/Dexie.Observable/test/unit/tests-observable-misc.js
@@ -257,7 +257,7 @@ asyncTest('sender should be able to react on broadcast if bIncludeSelf is true',
       });
 });
 
-// This tests relates to https://github.com/dfahlander/Dexie.js/issues/429#issuecomment-269793599
+// This tests relates to https://github.com/dexie/Dexie.js/issues/429#issuecomment-269793599
 // If db2 receives its message multiple times qunit will error as start() is called multiple times
 asyncTest('no matter how many times sendMessage is called a receiver should receive its message only once', 4, () => {
   const db1 = createDB();

--- a/addons/Dexie.Syncable/README.md
+++ b/addons/Dexie.Syncable/README.md
@@ -131,7 +131,7 @@ Get the options object for the given URL.
 
 ### Source
 
-[Dexie.Syncable.js](https://github.com/dfahlander/Dexie.js/blob/master/addons/Dexie.Syncable/src/Dexie.Syncable.js)
+[Dexie.Syncable.js](https://github.com/dexie/Dexie.js/blob/master/addons/Dexie.Syncable/src/Dexie.Syncable.js)
 
 ### Description
 

--- a/addons/Dexie.Syncable/dist/README.md
+++ b/addons/Dexie.Syncable/dist/README.md
@@ -1,6 +1,6 @@
 ## Can't find dexie-syncable.js?
 Transpiled code (dist version) IS ONLY checked in to
-the [releases](https://github.com/dfahlander/Dexie.js/tree/releases/addons/Dexie.Syncable/dist).
+the [releases](https://github.com/dexie/Dexie.js/tree/releases/addons/Dexie.Syncable/dist).
 branch.
 
 ## Download

--- a/addons/Dexie.Syncable/package.json
+++ b/addons/Dexie.Syncable/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfahlander/Dexie.js.git"
+    "url": "https://github.com/dexie/Dexie.js.git"
   },
   "keywords": [
     "indexeddb",
@@ -30,7 +30,7 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/dfahlander/Dexie.js/issues"
+    "url": "https://github.com/dexie/Dexie.js/issues"
   },
   "scripts": {
     "build": "just-build",

--- a/addons/dexie-cloud/package.json
+++ b/addons/dexie-cloud/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfahlander/Dexie.js.git"
+    "url": "https://github.com/dexie/Dexie.js.git"
   },
   "scripts": {
     "test": "just-build test && npm run test-unit",

--- a/addons/dexie-export-import/README.md
+++ b/addons/dexie-export-import/README.md
@@ -312,8 +312,8 @@ async function importDatabase(file) {
 
 This feature has been asked for a lot:
 
-* https://github.com/dfahlander/Dexie.js/issues/391
-* https://github.com/dfahlander/Dexie.js/issues/99
+* https://github.com/dexie/Dexie.js/issues/391
+* https://github.com/dexie/Dexie.js/issues/99
 * https://stackoverflow.com/questions/46025699/dumping-indexeddb-data
 * https://feathub.com/dfahlander/Dexie.js/+9
 

--- a/addons/dexie-export-import/package.json
+++ b/addons/dexie-export-import/package.json
@@ -7,7 +7,7 @@
   "typings": "dist/dexie-export-import.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfahlander/Dexie.js.git"
+    "url": "https://github.com/dexie/Dexie.js.git"
   },
   "scripts": {
     "test": "just-build test && npx karma start test/karma.conf.js --single-run",

--- a/libs/dexie-react-hooks/package.json
+++ b/libs/dexie-react-hooks/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dfahlander/Dexie.js.git"
+    "url": "git+https://github.com/dexie/Dexie.js.git"
   },
   "keywords": [
     "react",
@@ -44,9 +44,9 @@
   "author": "David Fahlander <https://github.com/dfahlander>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/dfahlander/Dexie.js/issues"
+    "url": "https://github.com/dexie/Dexie.js/issues"
   },
-  "homepage": "https://github.com/dfahlander/Dexie.js#readme",
+  "homepage": "https://dexie.org",
   "peerDependencies": {
     "@types/react": ">=16",
     "dexie": ">=3.1.0-alpha.1 <5.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dfahlander/Dexie.js.git"
+    "url": "https://github.com/dexie/Dexie.js.git"
   },
   "keywords": [
     "indexeddb",
@@ -57,7 +57,7 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/dfahlander/Dexie.js/issues"
+    "url": "https://github.com/dexie/Dexie.js/issues"
   },
   "scripts": {
     "build": "just-build",

--- a/samples/vue/README.md
+++ b/samples/vue/README.md
@@ -26,7 +26,7 @@ Run `npm run build` to build the project. The build artifacts will be stored in 
 
 * [Vue CLI guide](https://cli.vuejs.org)
 * [Vue.js Guide](https://v3.vuejs.org/guide/introduction.html) for core Vue 3 concepts
-* To get more help on Dexie check out the [Dexie Wiki](https://github.com/dfahlander/Dexie.js/wiki)
+* To get more help on Dexie check out the [Dexie Docs](https://dexie.org/docs/)
 
 
 ## See Also

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -489,7 +489,7 @@ promisedTest ("Should be able to use transpiled async await", async () => {
         ok(Dexie.currentTransaction === trans, "Transaction persisted between await calls of mixed promises");
 
     }).catch ('PrematureCommitError', ()=> {
-        ok(true, "PROMISE IS INCOMPATIBLE WITH INDEXEDDB (https://github.com/dfahlander/Dexie.js/issues/317). Ignoring test.");
+        ok(true, "PROMISE IS INCOMPATIBLE WITH INDEXEDDB (https://github.com/dexie/Dexie.js/issues/317). Ignoring test.");
     })
 });
 


### PR DESCRIPTION
From https://github.com/dfahlander/Dexie.js to
https://github.com/dexie/Dexie.js
Tried to replace the urls where they makes sense. Some old code comments might not be correct anymore so I left them as-is for now and did not rewrite.