### PR TITLE
Fix bug: Using dexie-cloud from Service Worker

### DIFF
--- a/addons/dexie-cloud/package-lock.json
+++ b/addons/dexie-cloud/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexie-cloud-addon",
-  "version": "4.0.0-beta.18",
+  "version": "4.0.0-beta.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dexie-cloud-addon",
-      "version": "4.0.0-beta.18",
+      "version": "4.0.0-beta.19",
       "license": "Apache-2.0",
       "dependencies": {
         "dexie-cloud-common": "^1.0.23"

--- a/addons/dexie-cloud/package.json
+++ b/addons/dexie-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-addon",
-  "version": "4.0.0-beta.18",
+  "version": "4.0.0-beta.19",
   "description": "Dexie addon that syncs with to Dexie Cloud",
   "main": "dist/umd/dexie-cloud-addon.js",
   "module": "dist/module-es5/dexie-cloud-addon.js",

--- a/addons/dexie-cloud/src/DexieCloudAPI.ts
+++ b/addons/dexie-cloud/src/DexieCloudAPI.ts
@@ -31,6 +31,7 @@ export interface DexieCloudAPI {
   //realms: Rx.Observable<DBRealm[]>;
   //loginState: Rx.BehaviorSubject<LoginState>;
   usingServiceWorker?: boolean;
+  isServiceWorkerDB?: boolean;
 
   /** Login using Dexie Cloud OTP or Demo user.
    *

--- a/addons/dexie-cloud/src/DexieCloudOptions.ts
+++ b/addons/dexie-cloud/src/DexieCloudOptions.ts
@@ -12,6 +12,7 @@ export interface DexieCloudOptions {
   unsyncedTables?: string[];
   periodicSync?: PeriodicSyncOptions;
   nameSuffix?: boolean;
+  disableWebSocket?: boolean;
   fetchTokens?: (tokenParams: {
     public_key: string;
     hints?: { userId?: string; email?: string };


### PR DESCRIPTION
Fix bug: dexieCloud addon did not work when used from within a service worker.
Observables were not setup correctly.

This PR also adds one new option to db.cloud.configure(): `{ disableWebSocket: boolean }`. By setting it to true, no websocket connection will be started by this instance of the db.

