### PR TITLE
4.0.0-alpha.3 - Reproduce: Node.js process not exiting when Dexie.js is imported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install: if [[ `npm -v` != 7* ]]; then npm i -g npm@7; fi
 addons:
   firefox: "85.0"
 node_js:
-  - "12"
+  - "18"
 matrix:
   fast_finish: true
 services:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "test": "npm run build && npm run test:typings && npm run test:unit",
     "test:unit": "karma start test/karma.conf.js --single-run",
     "test:typings": "tsc -p test/typings-test/",
-    "test:debug": "karma start test/karma.conf.js --log-level debug"
+    "test:debug": "karma start test/karma.conf.js --log-level debug",
+    "test:standalone": "node test/test-standalone.js"
   },
   "just-build": {
     "default": [

--- a/test/test-standalone.js
+++ b/test/test-standalone.js
@@ -1,0 +1,6 @@
+/**
+ * Just importing the Dexie.js library
+ * should not prevent a Node.js process from exiting.
+ */
+const { Dexie } = require('../');
+console.dir(Dexie);

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 npm run test:typings
 npm run test:unit
+npm run test:standalone


### PR DESCRIPTION
When Dexie.js is imported in a JavaScript file and run via Node.js, just importing the dexie.js library will prevent the process from exiting.

This happens with node.js >= 18.
It is not a problem with node.js 16 and below.

I think there is some side-effect like a setTimeout or setInterval that prevents the process from ever being finished.

I have this problem when using `4.0.0-alpha.3` in a test suite that is run via Node.js for faster test runs.