### PR TITLE
FIX #1576 Node.js process not exiting when Dexie.js is imported

### DIFF
--- a/src/live-query/enable-broadcast.ts
+++ b/src/live-query/enable-broadcast.ts
@@ -8,6 +8,18 @@ import { propagateLocally, propagatingLocally } from './propagate-locally';
 if (typeof BroadcastChannel !== 'undefined') {
   const bc = new BroadcastChannel(STORAGE_MUTATED_DOM_EVENT_NAME);
 
+  /**
+   * The Node.js BroadcastChannel will prevent the node process from exiting
+   * if the BroadcastChannel is not closed.
+   * Therefore we have to call unref() which allows the process to finish
+   * properly even when the BroadcastChannel is never closed.
+   * @link https://nodejs.org/api/worker_threads.html#broadcastchannelunref
+   * @link https://github.com/dexie/Dexie.js/pull/1576
+   */
+  if (typeof (bc as any).unref === 'function') {
+    (bc as any).unref();
+  }
+  
   //
   // Propagate local changes to remote tabs, windows and workers via BroadcastChannel
   //


### PR DESCRIPTION
A bugfix that ensures that importing Dexie.js in Node.js does not prevent the process from finishing. This is mostly relevant when Dexie.js is used in Node.js for unit tests.

Described problem without the fix: https://github.com/dexie/Dexie.js/pull/1576

Docs for the used `unref()` method:
https://nodejs.org/api/worker_threads.html#broadcastchannelunref