### PR TITLE
feat(d.ts): type creating hook subscriber return value

### DIFF
--- a/src/public/types/table-hooks.d.ts
+++ b/src/public/types/table-hooks.d.ts
@@ -19,7 +19,7 @@ interface DeletingHookContext<T,Key> {
 }
 
 interface TableHooks<T=any,TKey=IndexableType> extends DexieEventSet {
-  (eventName: 'creating', subscriber: (this: CreatingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => any): void;
+  (eventName: 'creating', subscriber: (this: CreatingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => void | undefined | TKey): void;
   (eventName: 'reading', subscriber: (obj:T) => T | any): void;
   (eventName: 'updating', subscriber: (this: UpdatingHookContext<T,TKey>, modifications:Object, primKey:TKey, obj:T, transaction:Transaction) => any): void;
   (eventName: 'deleting', subscriber: (this: DeletingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => any): void;


### PR DESCRIPTION
Hi.

Based on what I found writen in [docs](https://dexie.org/docs/Table/Table.hook('creating')) ...

>  // If returning any value other than undefined, the returned value will be used as primary key

... I feel like return type of `subscriber` param of `creating` table hook can be significantly improved. 