### PR TITLE
Revert to dexie 3 style Table<T, TKey>

### DIFF
--- a/addons/Dexie.Observable/package.json
+++ b/addons/Dexie.Observable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-observable",
-  "version": "4.0.0-beta.13",
+  "version": "4.0.1-beta.13",
   "packageManager": "^pnpm@7.9.5",
   "description": "Addon to Dexie that makes it possible to observe database changes no matter if they occur on other db instance or other window.",
   "main": "dist/dexie-observable.js",
@@ -79,11 +79,11 @@
   },
   "homepage": "https://dexie.org",
   "peerDependencies": {
-    "dexie": "workspace:^3.0.2 || ^4.0.0-alpha.1"
+    "dexie": "workspace:^3.0.2 || ^4.0.1-alpha.5"
   },
   "devDependencies": {
     "@types/node": "^18.7.14",
-    "dexie": "workspace:^3.0.2 || ^4.0.0-alpha.1",
+    "dexie": "workspace:^3.0.2 || ^4.0.1-alpha.5",
     "eslint": "^7.27.0",
     "just-build": "^0.9.24",
     "qunit": "^2.9.2",

--- a/addons/Dexie.Syncable/package.json
+++ b/addons/Dexie.Syncable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-syncable",
-  "version": "4.0.0-beta.13",
+  "version": "4.0.1-beta.13",
   "packageManager": "^pnpm@7.9.5",
   "description": "Addon to Dexie that makes it possible to sync indexeDB with remote databases.",
   "main": "dist/dexie-syncable.js",
@@ -71,11 +71,11 @@
   },
   "homepage": "https://dexie.org",
   "peerDependencies": {
-    "dexie": "workspace:^3.0.2 || ^4.0.0-alpha.1",
+    "dexie": "workspace:^3.0.2 || ^4.0.1-alpha.5",
     "dexie-observable": "workspace:^"
   },
   "devDependencies": {
-    "dexie": "workspace:^3.0.2 || ^4.0.0-alpha.1",
+    "dexie": "workspace:^3.0.2 || ^4.0.1-alpha.5",
     "dexie-observable": "workspace:^",
     "eslint": "^5.16.0",
     "just-build": "^0.9.24",

--- a/addons/dexie-cloud/package.json
+++ b/addons/dexie-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-addon",
-  "version": "4.0.0-beta.24",
+  "version": "4.0.1-beta.26",
   "packageManager": "^pnpm@7.9.5",
   "description": "Dexie addon that syncs with to Dexie Cloud",
   "main": "dist/umd/dexie-cloud-addon.js",
@@ -110,7 +110,7 @@
     "dexie-cloud-common": "workspace:^1.0.23"
   },
   "peerDependencies": {
-    "dexie": "workspace:^4.0.0-alpha.3",
+    "dexie": "workspace:^4.0.1-alpha.5",
     "rxjs": "^7.x"
   }
 }

--- a/addons/dexie-cloud/src/DexieCloudTable.ts
+++ b/addons/dexie-cloud/src/DexieCloudTable.ts
@@ -1,6 +1,26 @@
-import { Table } from 'dexie';
+import { EntityTable, InsertType } from 'dexie';
 
+export interface DexieCloudEntity {
+  owner: string;
+  realmId: string;
+}
 
-export type DexieCloudTable<T = any, TKey = string> = Table<
-  T, TKey, 'realmId' | 'owner'
->;
+/** Don't force the declaration of owner and realmId on every entity (some 
+ * types may not be interested of these props if they are never going to be shared)
+ * Let the type system behave the same as the runtime and merge these props in automatically
+ * when declaring the table where the props aren't explicitely declared.
+ * User may also explicitely declare these props in order to manually set them when
+ * they are interested of taking control over access.
+ */
+type WithDexieCloudProps<T> = T extends DexieCloudEntity ? T : T & DexieCloudEntity;
+
+/** Syntactic sugar for declaring a synced table of arbritary entity.
+ * 
+ */
+export type DexieCloudTable<T = any, TKeyPropName extends keyof T = never> =
+  EntityTable<
+  WithDexieCloudProps<T>,
+    TKeyPropName,
+    InsertType<WithDexieCloudProps<T>, TKeyPropName | 'owner' | 'realmId'>
+  >;
+

--- a/addons/dexie-cloud/src/extend-dexie-interface.ts
+++ b/addons/dexie-cloud/src/extend-dexie-interface.ts
@@ -11,15 +11,17 @@ import { DexieCloudAPI } from './DexieCloudAPI';
 import { DexieCloudTable } from './DexieCloudTable';
 import { NewIdOptions } from './types/NewIdOptions';
 
+type Optional<T, Props extends keyof T> = Omit<T, Props> & Partial<T>;
+
 //
 // Extend Dexie interface
 //
 declare module 'dexie' {
   interface Dexie {
     cloud: DexieCloudAPI;
-    realms: Table<DBRealm, 'realmId', 'owner'>;
-    members: Table<DBRealmMember, 'id', 'realmId' | 'owner'>;
-    roles: Table<DBRealmRole, [string, string], 'owner'>;
+    realms: Table<DBRealm, string, Optional<DBRealm, 'realmId' | 'owner'>>;
+    members: Table<DBRealmMember, string, Optional<DBRealmMember, 'id' | 'owner'>>;
+    roles: Table<DBRealmRole, [string, string], Optional<DBRealmRole, 'owner'>>;
   }
 
   interface Table {

--- a/addons/dexie-export-import/package.json
+++ b/addons/dexie-export-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-export-import",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "packageManager": "^pnpm@7.9.5",
   "description": "Dexie addon that adds export and import capabilities",
   "main": "dist/dexie-export-import.js",
@@ -44,6 +44,6 @@
     "typeson-registry": "^1.0.0-alpha.21"
   },
   "peerDependencies": {
-    "dexie": "workspace:^2.0.4 || ^3.0.0 || ^4.0.0-alpha.1"
+    "dexie": "workspace:^2.0.4 || ^3.0.0 || ^4.0.1-alpha.5"
   }
 }

--- a/libs/dexie-cloud-common/package.json
+++ b/libs/dexie-cloud-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-common",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "packageManager": "^pnpm@7.9.5",
   "description": "Library for shared code between dexie-cloud-addon, dexie-cloud (CLI) and dexie-cloud-server",
   "type": "module",
@@ -15,7 +15,7 @@
   "author": "David Fahlander",
   "license": "Apache-2.0",
   "dependencies": {
-    "universal-imports": "^1.0.1"
+    "universal-imports": "^1.0.4"
   },
   "devDependencies": {
     "@types/node": "^18.7.14"

--- a/libs/dexie-react-hooks/package.json
+++ b/libs/dexie-react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-react-hooks",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "packageManager": "^pnpm@7.9.5",
   "description": "React hooks for reactive data fetching using Dexie.js",
   "main": "dist/dexie-react-hooks.js",
@@ -60,7 +60,7 @@
     "@types/qunit": "^2.9.6",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "dexie": "workspace:>=3.1.0-alpha.1 || ^4.0.0-alpha.1",
+    "dexie": "workspace:>=3.1.0-alpha.1 || ^4.0.1-alpha.5",
     "just-build": "^0.9.24",
     "qunit": "^2.12.0",
     "react": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie",
-  "version": "4.0.0-alpha.4",
+  "version": "4.0.1-alpha.5",
   "description": "A Minimalistic Wrapper for IndexedDB",
   "main": "dist/dexie.js",
   "module": "dist/dexie.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
   addons/Dexie.Observable:
     specifiers:
       '@types/node': ^18.7.14
-      dexie: workspace:^3.0.2 || ^4.0.0-alpha.1
+      dexie: workspace:^3.0.2 || ^4.0.1-alpha.5
       eslint: ^7.27.0
       just-build: ^0.9.24
       qunit: ^2.9.2
@@ -70,7 +70,7 @@ importers:
 
   addons/Dexie.Syncable:
     specifiers:
-      dexie: workspace:^3.0.2 || ^4.0.0-alpha.1
+      dexie: workspace:^3.0.2 || ^4.0.1-alpha.5
       dexie-observable: workspace:^
       eslint: ^5.16.0
       just-build: ^0.9.24
@@ -89,7 +89,7 @@ importers:
       '@rollup/plugin-commonjs': ^18.0.0
       '@rollup/plugin-node-resolve': ^11.2.1
       '@types/node': '*'
-      dexie: workspace:^4.0.0-alpha.3
+      dexie: workspace:^4.0.1-alpha.5
       dexie-cloud-common: workspace:^1.0.23
       dreambase-library: ^1.0.18
       just-build: '*'
@@ -141,7 +141,7 @@ importers:
       '@types/node': ^13.5.1
       base64-arraybuffer-es6: '*'
       clarinet: dfahlander/clarinet
-      dexie: workspace:^2.0.4 || ^3.0.0 || ^4.0.0-alpha.1
+      dexie: workspace:^2.0.4 || ^3.0.0 || ^4.0.1-alpha.5
       just-build: ^0.9.24
       rollup-plugin-alias: ^2.2.0
       typeson: ^5.8.2
@@ -161,9 +161,9 @@ importers:
   libs/dexie-cloud-common:
     specifiers:
       '@types/node': ^18.7.14
-      universal-imports: ^1.0.1
+      universal-imports: ^1.0.4
     dependencies:
-      universal-imports: 1.0.1
+      universal-imports: 1.0.4
     devDependencies:
       '@types/node': 18.7.14
 
@@ -175,7 +175,7 @@ importers:
       '@types/qunit': ^2.9.6
       '@types/react': ^17.0.0
       '@types/react-dom': ^17.0.0
-      dexie: workspace:>=3.1.0-alpha.1 || ^4.0.0-alpha.1
+      dexie: workspace:>=3.1.0-alpha.1 || ^4.0.1-alpha.5
       just-build: ^0.9.24
       qunit: ^2.12.0
       react: ^17.0.1
@@ -459,13 +459,6 @@ packages:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
-  /@types/node-fetch/2.5.10:
-    resolution: {integrity: sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==}
-    dependencies:
-      '@types/node': 18.7.14
-      form-data: 3.0.1
-    dev: false
-
   /@types/node/13.13.52:
     resolution: {integrity: sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==}
     dev: true
@@ -480,6 +473,7 @@ packages:
 
   /@types/node/18.7.14:
     resolution: {integrity: sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==}
+    dev: true
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
@@ -823,10 +817,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /asynckit/0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
-
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
@@ -1100,13 +1090,6 @@ packages:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
     dev: true
 
-  /combined-stream/1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
-
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -1257,11 +1240,6 @@ packages:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /delayed-stream/1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: false
 
   /depd/1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -1816,15 +1794,6 @@ packages:
       debug:
         optional: true
     dev: true
-
-  /form-data/3.0.1:
-    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.30
-    dev: false
 
   /fresh/0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -2568,22 +2537,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /mime-db/1.47.0:
-    resolution: {integrity: sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==}
-    engines: {node: '>= 0.6'}
-    dev: false
-
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
     dev: true
-
-  /mime-types/2.1.30:
-    resolution: {integrity: sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.47.0
-    dev: false
 
   /mime-types/2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
@@ -3985,22 +3942,12 @@ packages:
     hasBin: true
     dev: true
 
-  /universal-imports/1.0.1:
-    resolution: {integrity: sha512-sJ0+vSN+S7X8gkrsAr+uugWSWLF/0xsgoTXN8+o5upBegEQlv5X09+FjMQhWu6KC+iabm0BbFtlgJV4aRxKYEQ==}
-    dependencies:
-      '@types/node-fetch': 2.5.10
-      node-fetch: 2.6.7
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /universal-imports/1.0.4:
     resolution: {integrity: sha512-/oEtKj4CAV5Xf1Ly9SupMbAeOUoTxFxW/BYoXlktQDsMDrO+dlt37Hz8rgqr3irfcKmVf76zkytfGzW+FYdHSg==}
     dependencies:
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}

--- a/src/public/index.d.ts
+++ b/src/public/index.d.ts
@@ -27,6 +27,7 @@ import { IntervalTree, RangeSetConstructor } from './types/rangeset';
 import { Dexie, TableProp } from './types/dexie';
 export type { TableProp };
 export * from './types/entity';
+export * from './types/entity-table';
 export { UpdateSpec } from './types/update-spec';
 export * from './types/insert-type';
 

--- a/src/public/types/entity-table.d.ts
+++ b/src/public/types/entity-table.d.ts
@@ -1,0 +1,19 @@
+import { IndexableType } from "..";
+import { InsertType } from "./insert-type";
+import { IsStrictlyAny } from "./is-strictly-any";
+import { Table } from "./table";
+
+/** IDType extract the actual type of the primary key:
+ *  * If TKey is a literal type that names a property of T, extract the type using T[TKey]
+ *  * Else, use TKey as is.
+ */
+export type IDType<T, TKeyPropNameOrKeyType> = IsStrictlyAny<T> extends true
+  ? TKeyPropNameOrKeyType
+  : TKeyPropNameOrKeyType extends string
+  ? TKeyPropNameOrKeyType extends keyof T
+    ? T[TKeyPropNameOrKeyType]
+    : TKeyPropNameOrKeyType
+  : TKeyPropNameOrKeyType;
+
+export type EntityTable<T, TKeyPropName extends keyof T = never, TInsertType = InsertType<T, TKeyPropName>> = Table<T, IDType<T, TKeyPropName>, TInsertType>;
+

--- a/src/public/types/insert-type.d.ts
+++ b/src/public/types/insert-type.d.ts
@@ -1,19 +1,17 @@
-export type MethodProps<T> = {
-  [P in keyof T]: T[P] extends (...args: any[]) => any ? P : never;
+import { IsStrictlyAny } from "./is-strictly-any";
+
+/** Extract the union of literal method names in T
+ */
+ export type MethodProps<T> = {
+  [P in keyof T]: IsStrictlyAny<T[P]> extends true
+    ? never // Plain property of type any (not method)
+    : T[P] extends (...args: any[]) => any
+    ? P // a function (method)
+    : never; // Not function (not method)
 }[keyof T];
 
-export type InsertType<T, TOptionalProperties, TKeyPropNameOrKeyType> = string extends MethodProps<T>
-  ? T
-  : Omit<
-      T,
-      TOptionalProperties extends keyof T
-        ? TKeyPropNameOrKeyType extends keyof T
-          ? MethodProps<T> | TOptionalProperties | TKeyPropNameOrKeyType
-          : MethodProps<T> | TOptionalProperties
-        : MethodProps<T>
-    > &
-      (TOptionalProperties extends keyof T
-        ? TKeyPropNameOrKeyType extends keyof T
-          ? { [P in (TOptionalProperties | TKeyPropNameOrKeyType)]?: T[P] }
-          : { [P in TOptionalProperties]?: T[P] }
-        : {});
+/** Default insert type of T is a subset of T where:
+ *    * given optional props (such as an auto-generated primary key) are made optional
+ *    * methods are omitted
+ */
+ export type InsertType<T, OptionalProps extends keyof T> = Omit<T, OptionalProps | MethodProps<T>> & {[P in OptionalProps]?: T[P]};

--- a/src/public/types/is-strictly-any.d.ts
+++ b/src/public/types/is-strictly-any.d.ts
@@ -1,0 +1,1 @@
+export type IsStrictlyAny<T> = (T extends never ? true : false) extends false ? false : true;

--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -7,62 +7,59 @@ import { WhereClause } from "./where-clause";
 import { PromiseExtended } from "./promise-extended";
 import { IndexableType } from "./indexable-type";
 import { DBCoreTable } from "./dbcore";
-import { InsertType } from "./insert-type";
-import { KeyPaths, KeyPathValue } from "./keypaths";
 import { Dexie } from "./dexie";
 import { UpdateSpec } from "./update-spec";
 
-export type IDType<T, TKey> = TKey extends keyof T ? T[TKey] : TKey;
-export interface Table<T=any, TKeyPropNameOrKeyType=IndexableType, TOpt=void> {
+export interface Table<T=any, TKey=IndexableType, TInsertType=T> {
   db: Dexie;
   name: string;
   schema: TableSchema;
-  hook: TableHooks<T, IDType<T, TKeyPropNameOrKeyType>>;
+  hook: TableHooks<T, TKey>;
   core: DBCoreTable;
 
-  get(key: IDType<T, TKeyPropNameOrKeyType>): PromiseExtended<T | undefined>;
-  get<R>(key: IDType<T, TKeyPropNameOrKeyType>, thenShortcut: ThenShortcut<T | undefined,R>): PromiseExtended<R>;
+  get(key: TKey): PromiseExtended<T | undefined>;
+  get<R>(key: TKey, thenShortcut: ThenShortcut<T | undefined,R>): PromiseExtended<R>;
   get(equalityCriterias: {[key:string]:any}): PromiseExtended<T | undefined>;
   get<R>(equalityCriterias: {[key:string]:any}, thenShortcut: ThenShortcut<T | undefined, R>): PromiseExtended<R>;
-  where(index: string | string[]): WhereClause<T, IDType<T, TKeyPropNameOrKeyType>>;
-  where(equalityCriterias: {[key:string]:any}): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
+  where(index: string | string[]): WhereClause<T, TKey>;
+  where(equalityCriterias: {[key:string]:any}): Collection<T, TKey>;
 
-  filter(fn: (obj: T) => boolean): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
+  filter(fn: (obj: T) => boolean): Collection<T, TKey>;
 
   count(): PromiseExtended<number>;
   count<R>(thenShortcut: ThenShortcut<number, R>): PromiseExtended<R>;
 
-  offset(n: number): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
+  offset(n: number): Collection<T, TKey>;
 
-  limit(n: number): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
+  limit(n: number): Collection<T, TKey>;
 
-  each(callback: (obj: T, cursor: {key: any, primaryKey: IDType<T, TKeyPropNameOrKeyType>}) => any): PromiseExtended<void>;
+  each(callback: (obj: T, cursor: {key: any, primaryKey: TKey}) => any): PromiseExtended<void>;
 
   toArray(): PromiseExtended<Array<T>>;
   toArray<R>(thenShortcut: ThenShortcut<T[], R>): PromiseExtended<R>;
 
-  toCollection(): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
-  orderBy(index: string | string[]): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
-  reverse(): Collection<T, IDType<T, TKeyPropNameOrKeyType>>;
+  toCollection(): Collection<T, TKey>;
+  orderBy(index: string | string[]): Collection<T, TKey>;
+  reverse(): Collection<T, TKey>;
   mapToClass(constructor: Function): Function;
-  add(item: InsertType<T, TOpt, TKeyPropNameOrKeyType>, key?: IDType<T, TKeyPropNameOrKeyType>): PromiseExtended<IDType<T, TKeyPropNameOrKeyType>>;
+  add(item: TInsertType, key?: TKey): PromiseExtended<TKey>;
   update(
-    key: IDType<T, TKeyPropNameOrKeyType> | T,
+    key: TKey | T,
     changes: UpdateSpec<T> | ((obj: T, ctx:{value: any, primKey: IndexableType}) => void | boolean)): PromiseExtended<number>;
-  put(item: InsertType<T, TOpt, TKeyPropNameOrKeyType>, key?: IDType<T, TKeyPropNameOrKeyType>): PromiseExtended<IDType<T, TKeyPropNameOrKeyType>>;
-  delete(key: IDType<T, TKeyPropNameOrKeyType>): PromiseExtended<void>;
+  put(item: TInsertType, key?: TKey): PromiseExtended<TKey>;
+  delete(key: TKey): PromiseExtended<void>;
   clear(): PromiseExtended<void>;
-  bulkGet(keys: IDType<T, TKeyPropNameOrKeyType>[]): PromiseExtended<(T | undefined)[]>;
+  bulkGet(keys: TKey[]): PromiseExtended<(T | undefined)[]>;
 
-  bulkAdd<B extends boolean>(items: readonly InsertType<T, TOpt, TKeyPropNameOrKeyType>[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): PromiseExtended<B extends true ? IDType<T, TKeyPropNameOrKeyType>[] : IDType<T, TKeyPropNameOrKeyType>>;
-  bulkAdd<B extends boolean>(items: readonly InsertType<T, TOpt, TKeyPropNameOrKeyType>[], options: { allKeys: B }): PromiseExtended<B extends true ? IDType<T, TKeyPropNameOrKeyType>[] : IDType<T, TKeyPropNameOrKeyType>>;
-  bulkAdd(items: readonly InsertType<T, TOpt, TKeyPropNameOrKeyType>[], keys?: IndexableTypeArrayReadonly, options?: { allKeys: boolean }): PromiseExtended<IDType<T, TKeyPropNameOrKeyType>>;
+  bulkAdd<B extends boolean>(items: readonly TInsertType[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): PromiseExtended<B extends true ? TKey[] : TKey>;
+  bulkAdd<B extends boolean>(items: readonly TInsertType[], options: { allKeys: B }): PromiseExtended<B extends true ? TKey[] : TKey>;
+  bulkAdd(items: readonly TInsertType[], keys?: IndexableTypeArrayReadonly, options?: { allKeys: boolean }): PromiseExtended<TKey>;
 
-  bulkPut<B extends boolean>(items: readonly InsertType<T, TOpt, TKeyPropNameOrKeyType>[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): PromiseExtended<B extends true ? IDType<T, TKeyPropNameOrKeyType>[] : IDType<T, TKeyPropNameOrKeyType>>;
-  bulkPut<B extends boolean>(items: readonly InsertType<T, TOpt ,TKeyPropNameOrKeyType>[], options: { allKeys: B }): PromiseExtended<B extends true ? IDType<T, TKeyPropNameOrKeyType>[] : IDType<T, TKeyPropNameOrKeyType>>;
-  bulkPut(items: readonly InsertType<T, TOpt, TKeyPropNameOrKeyType>[], keys?: IndexableTypeArrayReadonly, options?: { allKeys: boolean }): PromiseExtended<IDType<T, TKeyPropNameOrKeyType>>;
+  bulkPut<B extends boolean>(items: readonly TInsertType[], keys: IndexableTypeArrayReadonly, options: { allKeys: B }): PromiseExtended<B extends true ? TKey[] : TKey>;
+  bulkPut<B extends boolean>(items: readonly TInsertType[], options: { allKeys: B }): PromiseExtended<B extends true ? TKey[] : TKey>;
+  bulkPut(items: readonly TInsertType[], keys?: IndexableTypeArrayReadonly, options?: { allKeys: boolean }): PromiseExtended<TKey>;
 
-  bulkUpdate(keysAndChanges: ReadonlyArray<{key: IDType<T, TKeyPropNameOrKeyType>, changes: UpdateSpec<T>}>): PromiseExtended<number>;
+  bulkUpdate(keysAndChanges: ReadonlyArray<{key: TKey, changes: UpdateSpec<T>}>): PromiseExtended<number>;
 
-  bulkDelete(keys: IDType<T, TKeyPropNameOrKeyType>[]): PromiseExtended<void>;
+  bulkDelete(keys: TKey[]): PromiseExtended<void>;
 }

--- a/test/typings-test/test-extend-dexie.ts
+++ b/test/typings-test/test-extend-dexie.ts
@@ -5,7 +5,7 @@ import {Dexie, Table, DexieConstructor, IndexableType} from '../../dist/dexie';
 // Extend Dexie interface
 //
 declare module '../../dist/dexie' {
-    interface Table<T, TKeyPropNameOrKeyType> {
+    interface Table<T, TKey> {
         extendedTableMethod() : any;
     }
     interface DbEvents {

--- a/test/typings-test/test-typings.ts
+++ b/test/typings-test/test-typings.ts
@@ -3,7 +3,7 @@
  * It tests Dexie.d.ts.
  */
 
-import Dexie from '../../dist/dexie'; // Imports the source Dexie.d.ts file
+import Dexie, { IndexableType, Table } from '../../dist/dexie'; // Imports the source Dexie.d.ts file
 import './test-extend-dexie';
 
 // constructor overloads:
@@ -76,6 +76,20 @@ import './test-extend-dexie';
         prop1: Date;
     }
 
+    class BaseEntity {
+        oid: string;
+        prop2: Date;
+        foo(): void {
+            console.log('foo');
+        }
+    }
+
+    class Entity3 extends BaseEntity {
+        prop1: Date;
+        foo2(): void {
+            console.log('foo');
+        }
+    }
     interface CompoundKeyEntity {
         firstName: string;
         lastName: string;
@@ -84,6 +98,9 @@ import './test-extend-dexie';
     class MyDatabase extends Dexie {
         friends: Dexie.Table<Friend, number>;
         table2: Dexie.Table<Entity2, string>;
+        table3: Dexie.Table<Entity3, 'oid'>;
+        table4: Dexie.Table<Entity3, string>;
+        table5: Table;
         compoundTable: Dexie.Table<CompoundKeyEntity, [string, string]>;
 
         constructor () {
@@ -91,10 +108,14 @@ import './test-extend-dexie';
             this.version(1).stores({
                 table1: '++id',
                 table2: 'oid',
+                table3: '++oid',
                 compoundTable: '[firstName+lastName]'
             });
         }
     }
+
+    const fooAny: string = 'null'
+    const foo: IndexableType = fooAny
 
     let db = new MyDatabase();
 


### PR DESCRIPTION
Revert to dexie@3.x style Table<T, TKey> but allow a 3rd optional parameter InsertType.

With inspiration from @nlaurie's PR's #1632 and #1635 and descriptions of the problems he faced with 4.0.0-alpha.4.

A complex type system can create hard-to-solve typing issues and trigger subtle bugs in the typescript compiler. It's also not good for backward compability with dexie@3.2.

TKey is now a plain key again, as in dexie 3.x.

To get the power from dexie@4.0.0-alpha.4's  Table<Entity, 'id'>: use the new generic EntityTable<T, PrimaryKeyProp>.

Using EntityTable instead of Table will opt-in to sugaring the InsertType by removing methods and making the primary key property optional in calls to table.add(), put(), bulkAdd(), bulkPut().

This is a suggestion for a solution of the problem discussed in #1632