### PR TITLE
Check BigInt availability without getting errors

### DIFF
--- a/addons/dexie-cloud/src/TSON.ts
+++ b/addons/dexie-cloud/src/TSON.ts
@@ -19,7 +19,7 @@ import { TypeDefSet } from 'dreambase-library/dist/typeson-simplified/TypeDefSet
 //     serverRev.rev = bigIntDef.bigint.revive(server.rev)
 //   else
 //     serverRev.rev = new FakeBigInt(server.rev)
-export const hasBigIntSupport = typeof BigInt(0) === 'bigint';
+export const hasBigIntSupport = typeof BigInt === 'function';
 
 function getValueOfBigInt(x: bigint | FakeBigInt | string) {
   if (typeof x === 'bigint') {

--- a/addons/dexie-cloud/src/TSON.ts
+++ b/addons/dexie-cloud/src/TSON.ts
@@ -19,7 +19,7 @@ import { TypeDefSet } from 'dreambase-library/dist/typeson-simplified/TypeDefSet
 //     serverRev.rev = bigIntDef.bigint.revive(server.rev)
 //   else
 //     serverRev.rev = new FakeBigInt(server.rev)
-export const hasBigIntSupport = typeof BigInt === 'function';
+export const hasBigIntSupport = typeof BigInt === 'function' && typeof BigInt(0) === 'bigint';
 
 function getValueOfBigInt(x: bigint | FakeBigInt | string) {
   if (typeof x === 'bigint') {


### PR DESCRIPTION
Seems like the check for BigInt was running the BigInt() function, which is not available on iOS 13.7 e.g. Just checking if it's a function seems to do the trick.