### PR TITLE
Add `.d.mts` files to support `import` types properly

### DIFF
--- a/import-wrapper-prod.d.mts
+++ b/import-wrapper-prod.d.mts
@@ -1,0 +1,2 @@
+export * from './dist/dexie.js';
+export { default } from './dist/dexie.js';

--- a/import-wrapper.d.mts
+++ b/import-wrapper.d.mts
@@ -1,0 +1,2 @@
+export * from './dist/dexie.js';
+export { default } from './dist/dexie.js';


### PR DESCRIPTION
Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

You can check the reported error [here](https://arethetypeswrong.github.io/?p=dexie%403.2.3)