### PR TITLE
Add `.d.mts` files to support `import` types properly

### DIFF
--- a/import-wrapper-prod.d.mts
+++ b/import-wrapper-prod.d.mts
@@ -1,0 +1,2 @@
+export * from './dist/dexie.js';
+export { default } from './dist/dexie.js';

--- a/import-wrapper.d.mts
+++ b/import-wrapper.d.mts
@@ -1,0 +1,2 @@
+export * from './dist/dexie.js';
+export { default } from './dist/dexie.js';


### PR DESCRIPTION
PR #1711 targeted master only and will become a dexie@4 release.
This is the corresponding PR for dexie 3.x.
