### PR TITLE
Fix optimistic updates

### DIFF
--- a/libs/dexie-react-hooks/package.json
+++ b/libs/dexie-react-hooks/package.json
@@ -17,9 +17,9 @@
       "karma start test/karma.conf.js --single-run"
     ],
     "build-tests": [
-      "#just-build dexie",
+      "#just-build tests",
       "cd test",
-      "webpack"
+      "webpack --mode development"
     ],
     "dexie": [
       "cd ../..",

--- a/libs/dexie-react-hooks/src/useObservable.ts
+++ b/libs/dexie-react-hooks/src/useObservable.ts
@@ -4,7 +4,8 @@ export interface InteropableObservable<T> {
     onNext: (x: T) => any,
     onError?: (error: any) => any
   ): (() => any) | { unsubscribe(): any };
-  getValue?(): T;
+  getValue?(): T; // For BehaviorSubject
+  hasValue?(): boolean; // For liveQuery observable returning false until a value is available
 }
 
 export function useObservable<T, TDefault>(
@@ -79,7 +80,7 @@ export function useObservable<T, TDefault>(
       if (typeof observable.getValue === 'function') {
         monitor.current.result = observable.getValue();
         monitor.current.hasResult = true;
-      } else {
+      } else if (typeof observable.hasValue !== 'function' || observable.hasValue()) {
         // Find out if the observable has a current value: try get it by subscribing and
         // unsubscribing synchronously
         const subscription = observable.subscribe((val) => {

--- a/libs/dexie-react-hooks/test/components/App.tsx
+++ b/libs/dexie-react-hooks/test/components/App.tsx
@@ -9,7 +9,17 @@ export function App() {
   return <ErrorBoundary>
     <div id="list">
       <h2>All items</h2>
-      <ItemListComponent loadItems={()=>db.items.toArray()} />
+      <ItemListComponent loadItems={async ()=> {
+        console.log("Liading items...");
+        try {
+          const items = await db.items.toArray();
+          console.log("got items", items);
+          return items;
+          } catch (ex) {
+          console.error("Error loading items", ex);
+          throw ex;
+        }
+      }} />
     </div>
     <div id="current">
         <h2>Current item</h2>

--- a/libs/dexie-react-hooks/test/db/index.ts
+++ b/libs/dexie-react-hooks/test/db/index.ts
@@ -5,7 +5,7 @@ export class TestUseLiveQueryDB extends Dexie {
   items!: Table<Item, number>;
 
   constructor() {
-    super("TestUseLiveQuery");
+    super("TestUseLiveQuery", {cache: 'immutable'});
     this.version(1).stores({
       items: "id"
     });

--- a/libs/dexie-react-hooks/test/index.ts
+++ b/libs/dexie-react-hooks/test/index.ts
@@ -2,45 +2,32 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { module, test, equiv, assert } from "qunit";
 import { db } from "./db";
-import { BinarySemaphore } from "./utils/BinarySemaphore";
 import { App } from "./components/App";
-import { closest } from "./utils/closest";
+import { waitTilEqual } from "./utils/waitTilEqual";
+import { waitTilOk } from "./utils/waitTilOk";
 
-const listChanged = new BinarySemaphore();
-const currentChanged = new BinarySemaphore();
-const rootChanged = new BinarySemaphore();
-const mo = new MutationObserver(muts=>{
-  rootChanged.post();
-  if (muts.some(({target}) => closest(target, "div#list"))) {
-    listChanged.post();
-  } else if (muts.some(({target}) => closest(target, "div#current"))) {
-    currentChanged.post();
-  }
-});
 const div = document.createElement('div');
+
+document.body.insertAdjacentHTML('beforeend', `<div style="margin-top: 300px;"></div>`);
 document.body.appendChild(div);
 ReactDOM.render(React.createElement(App), div);
-mo.observe(div, {subtree: true, childList: true, characterData: true});
 
-module("useLiveQuery", {
-  beforeEach (assert) {
+module('useLiveQuery', {
+  async beforeEach(assert) {
     const done = assert.async();
-    db.items.clear().then(async ()=>{
-      listChanged.reset();
-      currentChanged.reset();
-      while(/Loading/i.test(div.innerText) || !/NOT_FOUND/i.test(div.innerText)) {
-        listChanged.reset();
-        currentChanged.reset();
-        await Promise.race([listChanged, currentChanged]);
-      }
+    try {
+      console.log("Clearing database");
+      await db.items.clear();
+      console.log("Successfully cleared database");
+    } finally {
       done();
-    })    
-  }
+    }
+  },
 });
 
 test("List component is reacting to changes", async ()=>{
   // Add items:
-  listChanged.reset();
+  console.log("Putting items");
   await db.items.bulkPut([{
     id: 1,
     name: "Hello",
@@ -49,58 +36,64 @@ test("List component is reacting to changes", async ()=>{
     name: "World"
   }]);
   console.log("after bulkPut");
-  await listChanged;
-  console.log("after await listChanged");
-  const list = div.querySelector("ul#itemList");
-  assert.equal(list?.textContent, "ID: 1Name: HelloID: 2Name: World", "The list should be populated");
+  await waitTilEqual(
+    ()=>div.querySelector("ul#itemList")?.textContent,
+    "ID: 1Name: HelloID: 2Name: World",
+    "The list should be populated"
+  );
 
   // Remove an item:
-  listChanged.reset();
   db.items.delete(2);
-  await listChanged;
-  assert.equal(list?.textContent, "ID: 1Name: Hello", "The second item should have been removed");
+  await waitTilEqual(
+    ()=>div.querySelector("ul#itemList")?.textContent,
+    "ID: 1Name: Hello",
+    "The second item should have been removed"
+  );
 
   // Update an item:
-  listChanged.reset();
   await db.items.update(1, {name: "Hola"});
-  await listChanged;
-  assert.equal(list?.textContent, "ID: 1Name: Hola", "The first item should have been updated");
+  await waitTilEqual(
+    ()=>div.querySelector("ul#itemList")?.textContent,
+    "ID: 1Name: Hola",
+    "The first item should have been updated");
 });
 
 test("ItemLoaderComponent is reacting to changes", async ()=>{
   const divCurrent = div.querySelector("div#current")!;
-  let pNotFoundItem = divCurrent.querySelector("p.not-found-item");  
   // Initial value when loaded - should be "not found"
-  assert.equal(pNotFoundItem?.textContent, "NOT_FOUND: 1", "Before we add anything - the component should say NOT_FOUND: 1");
+  waitTilEqual(()=>{
+    let pNotFoundItem = divCurrent.querySelector("p.not-found-item");  
+    return pNotFoundItem?.textContent;
+  }, "NOT_FOUND: 1", "Before we add anything - the component should say NOT_FOUND: 1");
   // Add items:
-  currentChanged.reset();
   await db.items.put({
     id: 1,
     name: "Foo",
   });
-  await currentChanged;
-  let current = divCurrent.querySelector("div#item-1");
-  assert.equal(current?.textContent, "ID: 1Name: Foo", "Current item should have been rendered");
+  await waitTilEqual(
+    ()=>divCurrent.querySelector("div#item-1")?.textContent,
+    "ID: 1Name: Foo",
+    "Current item should have been rendered");
 
   // Update it:
-  currentChanged.reset();
   await db.items.update(1, {name: "Bar"});
-  await currentChanged;
-  assert.equal(current?.textContent, "ID: 1Name: Bar", "Current item should have been updated");
+  await waitTilEqual(
+    ()=>divCurrent.querySelector("div#item-1")?.textContent,
+    "ID: 1Name: Bar",
+    "Current item should have been updated");
 
   // Remove it:
-  currentChanged.reset();
   db.items.delete(1);
-  await currentChanged;
-  current = divCurrent.querySelector("div#item-1");
-  pNotFoundItem = divCurrent.querySelector("p.not-found-item");
-  assert.ok(!current, "Item 1 should not be in the DOM tree anymore");
-  assert.equal(pNotFoundItem?.textContent, "NOT_FOUND: 1", "After deleting it - the component should say NOT_FOUND: 1");
+  await waitTilOk(()=>{
+    const current = divCurrent.querySelector("div#item-1");
+    const pNotFoundItem = divCurrent.querySelector("p.not-found-item");
+    return !current
+  }, "Item 1 should not be in the DOM tree anymore");
+  assert.equal(divCurrent.querySelector("p.not-found-item")?.textContent, "NOT_FOUND: 1", "After deleting it - the component should say NOT_FOUND: 1");
 });
 
 test("Clicking next button will update the currently viewed item", async ()=>{
   const divCurrent = div.querySelector("div#current")!;
-  currentChanged.reset();
   // Add items:
   await db.items.bulkPut([{
     id: 1,
@@ -110,21 +103,13 @@ test("Clicking next button will update the currently viewed item", async ()=>{
     name: "World"
   }]);
 
-  await currentChanged;
-  assert.equal(divCurrent.textContent, "Current itemID: 1Name: Hello", "We are now vieweing item 1");
+  await waitTilEqual(()=>divCurrent.textContent, "Current itemID: 1Name: Hello", "We are now vieweing item 1");
 
   // Click next button and verify we are then viewing item 2
-  currentChanged.reset();
   const btnNext = div.querySelector("#btnNext");
   // Click button:
   (btnNext as HTMLElement).click();
-  await currentChanged;
-  // While loading number 2, wait till it's not loading anymore:
-  while(/loading/i.test(divCurrent.textContent!)) {
-    currentChanged.reset();
-    await currentChanged;
-  }
-  assert.equal(divCurrent.textContent, "Current itemID: 2Name: World", "We are now viewering item 2");
+  await waitTilEqual(()=>divCurrent.textContent, "Current itemID: 2Name: World", "We are now vieweing item 2");
 });
 
 test("Selecting invalid key trigger the err-boundrary", async ()=>{
@@ -143,8 +128,6 @@ test("Selecting invalid key trigger the err-boundrary", async ()=>{
   
   
 
-  listChanged.reset();
-  currentChanged.reset();
   // Add some data:
   await db.items.bulkPut([{
     id: 1,
@@ -155,17 +138,15 @@ test("Selecting invalid key trigger the err-boundrary", async ()=>{
   }]);
 
   // Wait for both parts to update...
-  await Promise.all([listChanged, currentChanged]);
+  await waitTilOk(()=>{
+    const list = div.querySelector("ul#itemList")?.textContent;
+    return list === "ID: 1Name: HelloID: 2Name: World";
+  }, "We have a inital setup with two items in the list: 'Hello' and 'World'");
 
   // Now click the invalid key and wait for a render:
-  rootChanged.reset();
   // Click a bad button:
   (div.querySelector("#btnInvalidKey") as HTMLElement).click();
-  while (!/Something went wrong/g.test(div.innerText)) {
-    await rootChanged;
-    rootChanged.reset();
-  }
-  assert.ok(/Something went wrong/.test(div.innerText), "The ErrorBoundrary should be shown");
+  await waitTilOk(()=>/Something went wrong/.test(div.innerText), "The error boundrary should be shown");
   
   // Restore the gui from the error state:
   (div.querySelector("#btnFirst") as HTMLElement).click();

--- a/libs/dexie-react-hooks/test/utils/sleep.ts
+++ b/libs/dexie-react-hooks/test/utils/sleep.ts
@@ -1,0 +1,11 @@
+export function sleep(ms: number, signal?: AbortSignal) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        clearTimeout(timeout);
+        reject(new DOMException('Aborted', 'AbortError'));
+      });
+    }
+  });
+}

--- a/libs/dexie-react-hooks/test/utils/timeout.ts
+++ b/libs/dexie-react-hooks/test/utils/timeout.ts
@@ -1,0 +1,5 @@
+export function timeout(ms): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}

--- a/libs/dexie-react-hooks/test/utils/waitTilEqual.ts
+++ b/libs/dexie-react-hooks/test/utils/waitTilEqual.ts
@@ -1,0 +1,26 @@
+import { assert } from 'qunit';
+
+export function waitTilEqual(
+  getActual: () => any,
+  expected: any,
+  description: string,
+  timeout = 2000
+) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      const actual = getActual();
+      if (actual === expected) {
+        clearInterval(interval);
+        assert.equal(actual, expected, description);
+        resolve(true);
+      } else if (Date.now() - start > timeout) {
+        clearInterval(interval);
+        assert.equal(actual, expected, description);
+        resolve(false);
+      }
+    }, 10);
+  });
+}
+
+

--- a/libs/dexie-react-hooks/test/utils/waitTilOk.ts
+++ b/libs/dexie-react-hooks/test/utils/waitTilOk.ts
@@ -1,0 +1,22 @@
+import { assert } from 'qunit';
+
+export function waitTilOk(
+  evaluateCondition: () => boolean,
+  description: string,
+  timeout = 2000
+) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      if (evaluateCondition()) {
+        clearInterval(interval);
+        assert.ok(true, description);
+        resolve(true);
+      } else if (Date.now() - start > timeout) {
+        clearInterval(interval);
+        assert.ok(false, description);
+        resolve(false);
+      }
+    }, 10);
+  });
+}

--- a/src/classes/observable/observable.ts
+++ b/src/classes/observable/observable.ts
@@ -11,6 +11,9 @@ const symbolObservable: typeof Symbol.observable =
 
 export class Observable<T> implements IObservable<T> {
   private _subscribe: (observer: Observer<T>) => Subscription;
+  hasValue?: ()=>boolean;
+  getValue?: ()=>T;
+
   constructor(subscribe: (observer: Observer<T>) => Subscription) {
     this._subscribe = subscribe;
   }

--- a/src/functions/temp-transaction.ts
+++ b/src/functions/temp-transaction.ts
@@ -55,7 +55,7 @@ export function tempTransaction (
       //       });
       //   });
       //
-      trans.idbtrans.commit();
+      if (mode === 'readwrite') try {trans.idbtrans.commit();} catch {}
       return mode === 'readonly' ? result : trans._completion.then(() => result);
     });/*.catch(err => { // Don't do this as of now. If would affect bulk- and modify methods in a way that could be more intuitive. But wait! Maybe change in next major.
           trans._reject(err);

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -249,6 +249,12 @@ export const asyncIteratorSymbol = typeof Symbol !== 'undefined'
     ? Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator")
     : '@asyncIterator';
 
+export function delArrayItem(a: any[], x: any) {
+    const i = a.indexOf(x);
+    if (i >= 0) a.splice(i, 1);
+    return i >= 0;
+}
+
 export const NO_CHAR_ARRAY = {};
 // Takes one or several arguments and returns an array based on the following criteras:
 // * If several arguments provided, return arguments converted to an array in a way that

--- a/src/live-query/cache/subscribe-cachentry.ts
+++ b/src/live-query/cache/subscribe-cachentry.ts
@@ -1,3 +1,4 @@
+import { delArrayItem } from "../../functions/utils";
 import { CacheEntry } from "../../public/types/cache";
 
 export function subscribeToCacheEntry(cacheEntry: CacheEntry, container: CacheEntry[], requery: ()=>void, signal: AbortSignal) {
@@ -14,8 +15,7 @@ export function subscribeToCacheEntry(cacheEntry: CacheEntry, container: CacheEn
 function enqueForDeletion(cacheEntry: CacheEntry, container: CacheEntry[]) {
   setTimeout(() => {
     if (cacheEntry.subscribers.size === 0) { // Still empty (no new subscribers readded after grace time)
-      const pos = container.indexOf(cacheEntry);
-      if (pos > -1) container.splice(pos, 1);
+      delArrayItem(container, cacheEntry);
     }
   }, 3000);
 }

--- a/src/live-query/live-query.ts
+++ b/src/live-query/live-query.ts
@@ -64,7 +64,10 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
         closed = true;
         if (abortController) abortController.abort();
         globalEvents.storagemutated.unsubscribe(mutationListener);
-        txs.forEach(idbtrans => {try {idbtrans.abort();} catch {}});
+        txs.forEach(idbtrans => {
+          //@ts-ignore
+          idbtrans.aborted = true;
+          try { idbtrans.abort(); } catch {}});
       },
     };
 
@@ -101,7 +104,10 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
       abortController = new AbortController();
       
       if (txs.length) {
-        txs.forEach(idbtrans => {try {idbtrans.abort();} catch {}});
+        txs.forEach(idbtrans => {
+          //@ts-ignore
+          idbtrans.aborted = true;
+          try {idbtrans.abort();} catch {}});
         txs.length = 0;
       }
       const ctx: LiveQueryContext = {

--- a/src/public/types/observable.d.ts
+++ b/src/public/types/observable.d.ts
@@ -15,6 +15,8 @@ interface Unsubscribable {
 export interface Observable<T = any> {
   subscribe(observerOrNext?: Observer<T> | ((value: T) => void)): Subscription;
   subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
+  getValue?(): T;
+  hasValue?(): boolean;
 
 	[Symbol.observable]: () => Subscribable<T>;
 }


### PR DESCRIPTION
The unit tests for dexie-react-hooks failed. This PR resolves the failures that happened and makes the test work simpler by also functioning in cache mode (when the liveQueries updates immediately).

The issues found in dexie's liveQuery and cache-middleware was the following:

* useObservable() will launch the querier immediately on component render to test if it could give out a synchronous value. This is generic code in order to support synchronous observables but isnt' very good with liveQuery observable since useLiveQuery() uses useObservable(liveQuery()) internally and useObservable() forces it to run a dummy query on every initial render of a component. This is optimized to not do that by inspecting hasValue() of the observable and if that function is present and returning false, don't care to try getting a synchronous value.
* The above behavior in combination with that we now abort the transaction when unsubscribing, caused the cache to store a failing promise.
* When the querier is executed next time (to actually care about what's coming), it will find the cached promise and wait for it (it doesn't know quite yet that it will be failing with AbortError). When it eventually fails, the valid liveQuery fails and the component throws and the ErrorBoundary is shown.
* Tried to workaround this by re-executing the query in case it was from the cache and fails. Still got error, this time Transaction is inactive. Turned out the reason for this is that the original transaction was lost while waiting for the promise in the cache (that eventually failed). So we actually had to launch a new and fresh readonly transaction when this happens. This solved the entire issue.
* Then, I also optimized so that useObservable doesn't try to subscribe to liveQuery observables immediately, but instead waits until the effect is launched and only fires queries towards indexedb when they are actually being observed.

I have also a corresponding PR for master-3 (dexie@3.x) that enables the `hasValue()` method on returned observables so that the next version of dexie-react-hooks will optimize also for dexie@3.

