### PR TITLE
Optimize live queries for useLiveQuery with dexie 3

### DIFF
--- a/src/classes/observable/observable.ts
+++ b/src/classes/observable/observable.ts
@@ -11,6 +11,9 @@ const symbolObservable: typeof Symbol.observable =
 
 export class Observable<T> implements IObservable<T> {
   private _subscribe: (observer: Observer<T>) => Subscription;
+  hasValue?: ()=>boolean;
+  getValue?: ()=>T;
+
   constructor(subscribe: (observer: Observer<T>) => Subscription) {
     this._subscribe = subscribe;
   }

--- a/src/public/types/observable.d.ts
+++ b/src/public/types/observable.d.ts
@@ -5,14 +5,22 @@ declare global {
     readonly observable: symbol;
   }
 }
+
+interface Subscribable<T> {
+  subscribe(observer: Partial<Observer<T>>): Unsubscribable;
+}
+
+interface Unsubscribable {
+  unsubscribe(): void;
+}
+
 export interface Observable<T = any> {
-  subscribe(
-    onNext?: ((value: T) => void) | null,
-    onError?: ((error: any) => void) | null,
-    onComplete?: (() => void) | null
-  ): Subscription;
-  subscribe(observer?: Observer<T> | null): Subscription;
-  [Symbol.observable]: () => Observable<T>;
+  subscribe(observerOrNext?: Observer<T> | ((value: T) => void)): Subscription;
+  subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
+  getValue?(): T;
+  hasValue?(): boolean;
+
+	[Symbol.observable]: () => Subscribable<T>;
 }
 
 export interface Subscription {


### PR DESCRIPTION
Next version of dexie-react-hooks will optimize for liveQueries, given that the observable returned by liveQuery() has a `hasValue()` method returning false on initial render.

This PR adjusts liveQuery() in dexie@3 to supply the `hasValue()` method so that next version of dexie-react-hooks will stop firing of the initial dummy query on component render.

This PR also updates the typings of the Observable returned by liveQuery to the same typings as are returned in dexie@4.
