### PR TITLE
Fix broadcasted updates for cached queries

### DIFF
--- a/src/live-query/cache/cache.ts
+++ b/src/live-query/cache/cache.ts
@@ -1,3 +1,36 @@
-import { GlobalQueryCache } from "../../public/types/cache";
+import { CacheEntry, GlobalQueryCache, TblQueryCache } from "../../public/types/cache";
+import { ObservabilitySet } from "../../public/types/db-events";
+import { obsSetsOverlap } from "../obs-sets-overlap";
 
 export const cache: GlobalQueryCache = {}
+
+export function invalidateCachedObservabilitySets (updateParts: ObservabilitySet) {
+  for (const key in updateParts) {
+    const parts = /^idb\:\/\/(.*)\/(.*)\//.exec(key);
+    if (parts) {
+      const [, dbName, tableName] = parts;
+      const tblCache = cache[`idb://${dbName}/${tableName}`];
+      if (tblCache) invalidateQueries(tblCache, updateParts);
+    }
+  }
+}
+
+function invalidateQueries(tblCache: TblQueryCache, mutatedParts: ObservabilitySet) {
+  const collectedSubscribers = new Set<() => void>();
+  const thingsToRemove:[string, Set<CacheEntry>][] = [];
+  for (const [indexName, entries] of Object.entries(tblCache.queries.query)) {
+    const entriesToRemove = new Set<CacheEntry>();
+    for (const entry of entries) {
+      if (entry.obsSet && obsSetsOverlap(mutatedParts, entry.obsSet)) {
+        entriesToRemove.add(entry);
+        entry.subscribers.forEach((requery) => collectedSubscribers.add(requery));
+      }
+    }
+    thingsToRemove.push([indexName, entriesToRemove]);
+  }
+  for (const [indexName, entriesToRemove] of thingsToRemove) {
+    tblCache.queries.query[indexName] =
+      tblCache.queries.query[indexName].filter(entry => !entriesToRemove.has(entry));
+  }
+  collectedSubscribers.forEach((requery) => requery());
+}

--- a/src/live-query/propagate-locally.ts
+++ b/src/live-query/propagate-locally.ts
@@ -1,6 +1,7 @@
 import { isIEOrEdge } from '../globals/constants';
 import { globalEvents, DEXIE_STORAGE_MUTATED_EVENT_NAME, STORAGE_MUTATED_DOM_EVENT_NAME } from '../globals/global-events';
 import { ObservabilitySet } from "../public/types/db-events";
+import { invalidateCachedObservabilitySets } from './cache/cache';
 
 if (typeof dispatchEvent !== 'undefined' && typeof addEventListener !== 'undefined') {
   globalEvents(DEXIE_STORAGE_MUTATED_EVENT_NAME, updatedParts => {
@@ -31,6 +32,7 @@ export function propagateLocally(updateParts: ObservabilitySet) {
   try {
     propagatingLocally = true;
     globalEvents.storagemutated.fire(updateParts);
+    invalidateCachedObservabilitySets(updateParts);
   } finally {
     propagatingLocally = wasMe;
   }


### PR DESCRIPTION
Fixed the bug that mutations on foreign tabs and workers did not invalidate cache nor retrigger queriers when using cache and optimistic updates.
