### PR TITLE
Undo PR #1459 as it seem to complicate things.

### DIFF
--- a/src/live-query/cache/cache-middleware.ts
+++ b/src/live-query/cache/cache-middleware.ts
@@ -33,13 +33,10 @@ export const cacheMiddleware: Middleware<DBCore> = {
           mutatedParts?: ObservabilitySet;
         };
         // Maintain TblQueryCache.ops array when transactions commit or abort
-        const { txs } = PSD as LiveQueryContext;
-        if (txs || mode === 'readwrite') {
-          if (txs) txs.push(idbtrans);
+        if (mode === 'readwrite') {
           const ac = new AbortController();
           const { signal } = ac;
           const endTransaction = (wasCommitted: boolean) => () => {
-            if (txs) delArrayItem(txs, idbtrans);
             ac.abort();
             if (mode === 'readwrite') {
               // Collect which subscribers to notify:
@@ -233,15 +230,7 @@ export const cacheMiddleware: Middleware<DBCore> = {
               });
               cacheEntry = {
                 obsSet: req.obsSet,
-                promise: promise.catch(error => {
-                  // In case the query operation failed to to have been aborted, we need
-                  // redo the query (without cache this time and with a brand new transaction)
-                  if ((req.trans as IDBTransaction & {aborted?: boolean}).aborted) {
-                    const trans = coreMW.transaction([tableName], 'readonly');
-                    return tableMW.query({...req, trans});
-                  }
-                  return Promise.reject(error);
-                }),
+                promise,
                 subscribers: new Set(),
                 type: 'query',
                 req,

--- a/src/live-query/observability-middleware.ts
+++ b/src/live-query/observability-middleware.ts
@@ -164,9 +164,6 @@ export const observabilityMiddleware: Middleware<DBCore> = {
               : subscr; // Explicit read transaction - track changes across entire live query
 
             if (isLiveQuery) {
-              // Abort handling
-              const { signal } = PSD as LiveQueryContext;
-              if (signal && signal.aborted) throw new exceptions.Abort();
               // Current zone want's to track all queries so they can be subscribed to.
               // (The query is executed within a "liveQuery" zone)
               // Check whether the query applies to a certain set of ranges:


### PR DESCRIPTION
Aborting transactions that aren't listened to can generate unhandled rejections and make applications less stable. It may also trigger browser bugs and complicate troubleshooting.

This commit undos the changes made in PR #1459 and allows transactions of unsubscribed liveQuery to continue their job.

We can then also skip the special treatment of cached promises that needed to generate new transaction to work around this when a new liveQuery tries to reuse the result of an aborted one.