### PR TITLE
Move cache middleware to level 0

### DIFF
--- a/src/classes/dexie/dexie.ts
+++ b/src/classes/dexie/dexie.ts
@@ -214,10 +214,10 @@ export class Dexie implements IDexie {
 
     // Default middlewares:
     this.use(cacheExistingValuesMiddleware);
-    this.use(virtualIndexMiddleware);
-    this.use(hooksMiddleware);
     this.use(cacheMiddleware);
     this.use(observabilityMiddleware);
+    this.use(virtualIndexMiddleware);
+    this.use(hooksMiddleware);
 
     this.vip = Object.create(this, {_vip: {value: true}}) as Dexie;
 

--- a/src/live-query/cache/cache-middleware.ts
+++ b/src/live-query/cache/cache-middleware.ts
@@ -18,7 +18,7 @@ import { subscribeToCacheEntry } from './subscribe-cachentry';
 
 export const cacheMiddleware: Middleware<DBCore> = {
   stack: 'dbcore',
-  level: 10,
+  level: 0,
   name: 'Cache',
   create: (core) => {
     const dbName = core.schema.name;

--- a/src/live-query/cache/cache-middleware.ts
+++ b/src/live-query/cache/cache-middleware.ts
@@ -33,13 +33,10 @@ export const cacheMiddleware: Middleware<DBCore> = {
           mutatedParts?: ObservabilitySet;
         };
         // Maintain TblQueryCache.ops array when transactions commit or abort
-        const { txs } = PSD as LiveQueryContext;
-        if (txs || mode === 'readwrite') {
-          if (txs) txs.push(idbtrans);
+        if (mode === 'readwrite') {
           const ac = new AbortController();
           const { signal } = ac;
           const endTransaction = (wasCommitted: boolean) => () => {
-            if (txs) delArrayItem(txs, idbtrans);
             ac.abort();
             if (mode === 'readwrite') {
               // Collect which subscribers to notify:
@@ -233,15 +230,7 @@ export const cacheMiddleware: Middleware<DBCore> = {
               });
               cacheEntry = {
                 obsSet: req.obsSet,
-                promise: promise.catch(error => {
-                  // In case the query operation failed to to have been aborted, we need
-                  // redo the query (without cache this time and with a brand new transaction)
-                  if ((req.trans as IDBTransaction & {aborted?: boolean}).aborted) {
-                    const trans = coreMW.transaction([tableName], 'readonly');
-                    return tableMW.query({...req, trans});
-                  }
-                  return Promise.reject(error);
-                }),
+                promise,
                 subscribers: new Set(),
                 type: 'query',
                 req,

--- a/src/live-query/observability-middleware.ts
+++ b/src/live-query/observability-middleware.ts
@@ -28,7 +28,7 @@ import { extendObservabilitySet } from "./extend-observability-set";
 
 export const observabilityMiddleware: Middleware<DBCore> = {
   stack: "dbcore",
-  level: 10,
+  level: 0,
   name: "Observability",
   create: (core) => {
     const dbName = core.schema.name;

--- a/src/live-query/observability-middleware.ts
+++ b/src/live-query/observability-middleware.ts
@@ -164,9 +164,6 @@ export const observabilityMiddleware: Middleware<DBCore> = {
               : subscr; // Explicit read transaction - track changes across entire live query
 
             if (isLiveQuery) {
-              // Abort handling
-              const { signal } = PSD as LiveQueryContext;
-              if (signal && signal.aborted) throw new exceptions.Abort();
               // Current zone want's to track all queries so they can be subscribed to.
               // (The query is executed within a "liveQuery" zone)
               // Check whether the query applies to a certain set of ranges:


### PR DESCRIPTION
Fixes issues when middlewars on level 1 and above modify mutations.

Cache middleware were on level 10 which made them not able to compute optimistic updates based on the modified mutations but rather on the original mutations only because it cached values before those middlwares injected their values.

This issue affected some dexie-cloud users because liveQueries did not return the correct values of "owner" and "realmId" of added objects.
