### PR TITLE
Update to Recursive Type reference

### DIFF
--- a/src/public/types/table-hooks.d.ts
+++ b/src/public/types/table-hooks.d.ts
@@ -18,9 +18,9 @@ interface DeletingHookContext<T,Key> {
   onerror?: (err: any) => void;
 }
 
-interface TableHooks<T=any,TKey=IndexableType> extends DexieEventSet {
+interface TableHooks<T=any,TKey=IndexableType,TInsertType=T> extends DexieEventSet {
   (eventName: 'creating', subscriber: (this: CreatingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => void | undefined | TKey): void;
-  (eventName: 'reading', subscriber: (obj:T) => T | any): void;
+  (eventName: 'reading', subscriber: (obj:TInsertType) => T | any): void;
   (eventName: 'updating', subscriber: (this: UpdatingHookContext<T,TKey>, modifications:Object, primKey:TKey, obj:T, transaction:Transaction) => any): void;
   (eventName: 'deleting', subscriber: (this: DeletingHookContext<T,TKey>, primKey:TKey, obj:T, transaction:Transaction) => any): void;
   creating: DexieEvent;

--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -14,7 +14,7 @@ export interface Table<T=any, TKey=any, TInsertType=T> {
   db: Dexie;
   name: string;
   schema: TableSchema;
-  hook: TableHooks<T, TKey>;
+  hook: TableHooks<T, TKey, TInsertType>;
   core: DBCoreTable;
 
   get(key: TKey): PromiseExtended<T | undefined>;
@@ -45,7 +45,7 @@ export interface Table<T=any, TKey=any, TInsertType=T> {
   add(item: TInsertType, key?: TKey): PromiseExtended<TKey>;
   update(
     key: TKey | T,
-    changes: UpdateSpec<T> | ((obj: T, ctx:{value: any, primKey: IndexableType}) => void | boolean)): PromiseExtended<number>;
+    changes: UpdateSpec<TInsertType> | ((obj: T, ctx:{value: any, primKey: IndexableType}) => void | boolean)): PromiseExtended<number>;
   put(item: TInsertType, key?: TKey): PromiseExtended<TKey>;
   delete(key: TKey): PromiseExtended<void>;
   clear(): PromiseExtended<void>;


### PR DESCRIPTION
Completion the the Pattern of TInsertType.  I found a Type recursion issue with my complex class types dealing with the updating and hooks.  Specifically the (UpdateSpec) since it generically looks at the passed in Type recursively it suffers from circular references on complex class types.   So I completed the pattern by passing along the TInsertType respectively.  if specifying the TInsertType it should be used universally to prevent leaky abstraction making it's way into Dexie Entity processing

Nick