### PR TITLE
Fix null object recovery

### DIFF
--- a/src/hooks/hooks-middleware.ts
+++ b/src/hooks/hooks-middleware.ts
@@ -71,7 +71,7 @@ export const hooksMiddleware: Middleware<DBCore>  = {
                 if (req.type === 'delete') {
                   // delete operation
                   deleting.fire.call(ctx, key, existingValue, dxTrans);
-                } else if (req.type === 'add' || existingValue === undefined) {
+                } else if (req.type === 'add' || existingValue == undefined) {
                   // The add() or put() resulted in a create
                   const generatedPrimaryKey = creating.fire.call(ctx, key, req.values[i], dxTrans);
                   if (key == null && generatedPrimaryKey != null) {

--- a/test/tests-crud-hooks.js
+++ b/test/tests-crud-hooks.js
@@ -849,3 +849,19 @@ promisedTest("issue #1270 Modification object in updating hook not correct when 
         await db.table1.put({id:1, author: {buf: buffer2}});
     }));
 });
+
+promisedTest("issue #1734 Cannot convert undefined or null to object in hooksMiddleware", async ()=>{
+    // Test recovering from null object
+    await expect([{
+        op: "create",
+        key: 1,
+        value: null
+    },{
+        op: "create",
+        key: 1,
+        value: {}
+    }], () => db.transaction('rw', db.table5, async ()=>{
+        await db.table5.put(null, 1);
+        await db.table5.put({}, 1);
+    }));
+});


### PR DESCRIPTION
Fix issue #1734 

If a table has a null object, perhaps because of open issue #541, then table.put on that object hits and error 'Cannot convert undefined or null to object' in hooksMiddleware, preventing the client easily recovering from the null object.

The fix is to treat updating a null object as object creation in hooksMiddleware.