### PR TITLE
Bugfix: Support single-valued compound keys

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -113,7 +113,7 @@ export function tryCatch(fn: (...args: any[])=>void, onerror, args?) : void {
 
 export function getByKeyPath(obj, keyPath) {
     // http://www.w3.org/TR/IndexedDB/#steps-for-extracting-a-key-from-a-value-using-a-key-path
-    if (hasOwn(obj, keyPath)) return obj[keyPath]; // This line is moved from last to first for optimization purpose.
+    if (typeof keyPath === 'string' && hasOwn(obj, keyPath)) return obj[keyPath]; // This line is moved from last to first for optimization purpose.
     if (!keyPath) return obj;
     if (typeof keyPath !== 'string') {
         var rv = [];


### PR DESCRIPTION
Javascript is a bit unsuprisingly forgiving when passing array of string instead of a string:
```js
const obj = {id: 1};
obj.hasOwnProperty("id"); // returns true as expected.
obj.hasOwnProperty(["id"]); // Also returns true (!)

obj["id"] // returns 1 as expected.
obj[["id"]] // also returns 1 (!)

```
This commit makes sure to check typeof keyPath before passing it to getOwn() (alias for `(x, a) => Object.prototype.getOwnProperty.call(x, a))``