### PR TITLE
Never throw VersionError

### DIFF
--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -78,9 +78,8 @@ export function dexieOpen (db: Dexie) {
             db.idbdb = req.result;
             if (schemaPatchMode) {
               patchCurrentVersion(db, upgradeTransaction);
-            } else {
-              runUpgraders(db, oldVer / 10, upgradeTransaction, reject);
             }
+            runUpgraders(db, oldVer / 10, upgradeTransaction, reject);
         }
     }, reject);
     

--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -5,7 +5,7 @@ import { exceptions } from '../../errors';
 import { eventRejectHandler, preventDefault } from '../../functions/event-wrappers';
 import Promise, { wrap } from '../../helpers/promise';
 import { connections } from '../../globals/constants';
-import { runUpgraders, readGlobalSchema, adjustToExistingIndexNames, verifyInstalledSchema } from '../version/schema-helpers';
+import { runUpgraders, readGlobalSchema, adjustToExistingIndexNames, verifyInstalledSchema, patchCurrentVersion } from '../version/schema-helpers';
 import { safariMultiStoreFix } from '../../functions/quirks';
 import { _onDatabaseCreated } from '../../helpers/database-enumerator';
 import { vip } from './vip';
@@ -30,6 +30,8 @@ export function dexieOpen (db: Dexie) {
   state.dbOpenError = null;
   state.openComplete = false;
   const openCanceller = state.openCanceller;
+  let nativeVerToOpen = Math.round(db.verno * 10);
+  let schemaPatchMode = false;
 
   function throwIfCancelled() {
     // If state.openCanceller object reference is replaced, it means db.close() has been called,
@@ -44,19 +46,14 @@ export function dexieOpen (db: Dexie) {
       wasCreated = false;
 
   const tryOpenDB = () => new Promise((resolve, reject) => {
-    // Multiply db.verno with 10 will be needed to workaround upgrading bug in IE:
-    // IE fails when deleting objectStore after reading from it.
-    // A future version of Dexie.js will stopover an intermediate version to workaround this.
-    // At that point, we want to be backward compatible. Could have been multiplied with 2, but by using 10, it is easier to map the number to the real version number.
-    
     throwIfCancelled();
     // If no API, throw!
     if (!indexedDB) throw new exceptions.MissingAPI();
     const dbName = db.name;
     
-    const req = state.autoSchema ?
+    const req = state.autoSchema || !nativeVerToOpen ?
       indexedDB.open(dbName) :
-      indexedDB.open(dbName, Math.round(db.verno * 10));
+      indexedDB.open(dbName, nativeVerToOpen);
     if (!req) throw new exceptions.MissingAPI(); // May happen in Safari private mode, see https://github.com/dfahlander/Dexie.js/issues/134
     req.onerror = eventRejectHandler(reject);
     req.onblocked = wrap(db._fireOnBlocked);
@@ -76,10 +73,14 @@ export function dexieOpen (db: Dexie) {
             });
         } else {
             upgradeTransaction.onerror = eventRejectHandler(reject);
-            var oldVer = e.oldVersion > Math.pow(2, 62) ? 0 : e.oldVersion; // Safari 8 fix.
+            const oldVer = e.oldVersion > Math.pow(2, 62) ? 0 : e.oldVersion; // Safari 8 fix.
             wasCreated = oldVer < 1;
             db.idbdb = req.result;
-            runUpgraders(db, oldVer / 10, upgradeTransaction, reject);
+            if (schemaPatchMode) {
+              patchCurrentVersion(db, upgradeTransaction);
+            } else {
+              runUpgraders(db, oldVer / 10, upgradeTransaction, reject);
+            }
         }
     }, reject);
     
@@ -94,8 +95,12 @@ export function dexieOpen (db: Dexie) {
           if (state.autoSchema) readGlobalSchema(db, idbdb, tmpTrans);
           else {
               adjustToExistingIndexNames(db, db._dbSchema, tmpTrans);
-              if (!verifyInstalledSchema(db, tmpTrans)) {
-                  console.warn(`Dexie SchemaDiff: Schema was extended without increasing the number passed to db.version(). Some queries may fail.`);
+              if (!verifyInstalledSchema(db, tmpTrans) && !schemaPatchMode) {
+                console.warn(`Dexie SchemaDiff: Schema was extended without increasing the number passed to db.version(). Dexie will add missing parts and increment native version number to workaround this.`);
+                idbdb.close();
+                ++nativeVerToOpen;
+                schemaPatchMode = true;
+                return resolve (tryOpenDB()); // Try again with new version (nativeVerToOpen
               }
           }
           generateMiddlewareStacks(db, tmpTrans);
@@ -125,15 +130,24 @@ export function dexieOpen (db: Dexie) {
 
     }, reject);
   }).catch(err => {
-    if (err && err.name === 'UnknownError' && state.PR1398_maxLoop > 0) {
-      // Bug in Chrome after clearing site data
-      // https://github.com/dexie/Dexie.js/issues/543#issuecomment-1795736695
-      state.PR1398_maxLoop--;
-      console.warn('Dexie: Workaround for Chrome UnknownError on open()');
-      return tryOpenDB();
-    } else {
-      return Promise.reject(err);
+    switch (err?.name) {
+      case "UnknownError":
+        if (state.PR1398_maxLoop > 0) {
+          // Bug in Chrome after clearing site data
+          // https://github.com/dexie/Dexie.js/issues/543#issuecomment-1795736695
+          state.PR1398_maxLoop--;
+          console.warn('Dexie: Workaround for Chrome UnknownError on open()');
+          return tryOpenDB();
+        }
+        break;
+      case "VersionError":
+        if (nativeVerToOpen > 0) {
+          nativeVerToOpen = 0;
+          return tryOpenDB();
+        }
+        break;
     }
+    return Promise.reject(err);
   });
   
   // safari14Workaround = Workaround by jakearchibald for new nasty bug in safari 14.

--- a/src/classes/dexie/dexie-open.ts
+++ b/src/classes/dexie/dexie-open.ts
@@ -98,7 +98,7 @@ export function dexieOpen (db: Dexie) {
               if (!verifyInstalledSchema(db, tmpTrans) && !schemaPatchMode) {
                 console.warn(`Dexie SchemaDiff: Schema was extended without increasing the number passed to db.version(). Dexie will add missing parts and increment native version number to workaround this.`);
                 idbdb.close();
-                ++nativeVerToOpen;
+                nativeVerToOpen = idbdb.version + 1;
                 schemaPatchMode = true;
                 return resolve (tryOpenDB()); // Try again with new version (nativeVerToOpen
               }

--- a/src/functions/temp-transaction.ts
+++ b/src/functions/temp-transaction.ts
@@ -21,7 +21,7 @@ export function tempTransaction (
       return rejection(new exceptions.DatabaseClosed(db._state.dbOpenError));
     }
     if (!db._state.isBeingOpened) {
-      if (!db._options.autoOpen)
+      if (!db._state.autoOpen)
         return rejection(new exceptions.DatabaseClosed());
       db.open().catch(nop); // Open in background. If if fails, it will be catched by the final promise anyway.
     }

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -328,9 +328,13 @@ asyncTest("PR #1108", async ()=>{
     }
     const origConsoleWarn = console.warn;
     const warnings = [];
-    console.warn = function(msg){warnings.push(msg); return origConsoleWarn.apply(this, arguments)};
+    console.warn = function(msg){
+        warnings.push(msg);
+        return origConsoleWarn.apply(this, arguments)
+    };
     try {
         const DBNAME = "PR1108";
+        await Dexie.delete(DBNAME);
         let db = new Dexie(DBNAME);
         db.version(1).stores({
             foo: "id"

--- a/test/tests-upgrading.js
+++ b/test/tests-upgrading.js
@@ -931,6 +931,10 @@ promisedTest(
 promisedTest(
     "Dexie 4: It should work having two versions of the DB opened at the same time as long as they have a compatible schema",
     async ()=>{
+        if (typeof Dexie.Observable?.version === 'string') {
+            ok(true, "Skipping this test - Dexie.Observable bails out when opening two versions of the same database");
+            return;
+        }
         const DBNAME = "competingDBs";
 
         await Dexie.delete(DBNAME);
@@ -978,7 +982,11 @@ promisedTest(
 );
 
 promisedTest("Dexie 4: An attached upgrader on version 2 and 3 shall run even if version 1 was reused for schema manipulation more than 20 times", async ()=>{
-    const DBNAME = "attachedUpgrader";
+    if (typeof Dexie.Observable?.version === 'string') {
+        ok(true, "Skipping this test - Dexie.Observable bails out when database reopen in background");
+        return;
+    }
+const DBNAME = "attachedUpgrader";
     const NUM_SCHEMA_CHANGES = 31; // 10 works but 11 fails unless we work around it in Dexie with a meta table.
 
     await Dexie.delete(DBNAME);

--- a/test/tests-upgrading.js
+++ b/test/tests-upgrading.js
@@ -986,7 +986,7 @@ promisedTest("Dexie 4: An attached upgrader on version 2 and 3 shall run even if
         ok(true, "Skipping this test - Dexie.Observable bails out when database reopen in background");
         return;
     }
-const DBNAME = "attachedUpgrader";
+    const DBNAME = "attachedUpgrader";
     const NUM_SCHEMA_CHANGES = 31; // 10 works but 11 fails unless we work around it in Dexie with a meta table.
 
     await Dexie.delete(DBNAME);


### PR DESCRIPTION
* Allow schema changes without version bump
* Allow downgrades
* Only require version bump when content upgrades are needed
