### PR TITLE
Support magic links for OTP emails

### DIFF
--- a/addons/dexie-cloud/src/DexieCloudAPI.ts
+++ b/addons/dexie-cloud/src/DexieCloudAPI.ts
@@ -12,6 +12,15 @@ import { BehaviorSubject, Observable } from 'rxjs';
 
 /** The API of db.cloud, where `db` is an instance of Dexie with dexie-cloud-addon active.
  */
+
+export interface LoginHints {
+  email?: string;
+  userId?: string;
+  grant_type?: 'demo' | 'otp';
+  otpId?: string;
+  otp?: string;
+}
+
 export interface DexieCloudAPI {
   // Version of dexie-cloud-addon
   version: string;
@@ -67,11 +76,7 @@ export interface DexieCloudAPI {
    * @param userId Optional userId to authenticate
    * @param grant_type requested grant type
    */
-  login(hint?: {
-    email?: string;
-    userId?: string;
-    grant_type?: 'demo' | 'otp';
-  }): Promise<void>;
+  login(hint?: LoginHints): Promise<void>;
 
   logout(options?: {force?: boolean}): Promise<void>;
 

--- a/addons/dexie-cloud/src/authentication/authenticate.ts
+++ b/addons/dexie-cloud/src/authentication/authenticate.ts
@@ -16,10 +16,11 @@ import {
 import { TokenErrorResponseError } from './TokenErrorResponseError';
 import { alertUser, interactWithUser } from './interactWithUser';
 import { InvalidLicenseError } from '../InvalidLicenseError';
+import { LoginHints } from '../DexieCloudAPI';
 
 export type FetchTokenCallback = (tokenParams: {
   public_key: string;
-  hints?: { userId?: string; email?: string; grant_type?: string };
+  hints?: LoginHints;
 }) => Promise<TokenFinalResponse | TokenErrorResponse>;
 
 export async function loadAccessToken(
@@ -63,7 +64,7 @@ export async function authenticate(
   context: UserLogin,
   fetchToken: FetchTokenCallback,
   userInteraction: BehaviorSubject<DXCUserInteraction | undefined>,
-  hints?: { userId?: string; email?: string; grant_type?: string }
+  hints?: LoginHints
 ): Promise<UserLogin> {
   if (
     context.accessToken &&
@@ -145,7 +146,7 @@ async function userAuthenticate(
   context: UserLogin,
   fetchToken: FetchTokenCallback,
   userInteraction: BehaviorSubject<DXCUserInteraction | undefined>,
-  hints?: { userId?: string; email?: string; grant_type?: string }
+  hints?: LoginHints
 ) {
   if (!crypto.subtle) {
     if (typeof location !== 'undefined' && location.protocol === 'http:') {

--- a/addons/dexie-cloud/src/authentication/login.ts
+++ b/addons/dexie-cloud/src/authentication/login.ts
@@ -1,4 +1,5 @@
 import { DexieCloudDB } from '../db/DexieCloudDB';
+import { LoginHints } from '../DexieCloudAPI';
 import { triggerSync } from '../sync/triggerSync';
 import { authenticate, loadAccessToken } from './authenticate';
 import { AuthPersistedContext } from './AuthPersistedContext';
@@ -9,7 +10,7 @@ import { UNAUTHORIZED_USER } from './UNAUTHORIZED_USER';
 
 export async function login(
   db: DexieCloudDB,
-  hints?: { email?: string; userId?: string; grant_type?: string }
+  hints?: LoginHints
 ) {
   const currentUser = await db.getCurrentUser();
   const origUserId = currentUser.userId;

--- a/libs/dexie-cloud-common/package.json
+++ b/libs/dexie-cloud-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-common",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Library for shared code between dexie-cloud-addon, dexie-cloud (CLI) and dexie-cloud-server",
   "type": "module",
   "module": "dist/index.js",

--- a/libs/dexie-cloud-common/src/types.ts
+++ b/libs/dexie-cloud-common/src/types.ts
@@ -1,16 +1,23 @@
 export type TokenRequest =
-  | OTPTokenRequest
+  | OTPTokenRequest1
+  | OTPTokenRequest2
   | ClientCredentialsTokenRequest
   | RefreshTokenRequest
   | DemoTokenRequest;
 
-export interface OTPTokenRequest {
+export type OTPTokenRequest = OTPTokenRequest1 | OTPTokenRequest2;
+export interface OTPTokenRequest1 {
   grant_type: 'otp';
-  public_key?: string; // If a refresh token is requested. Clients own the keypair and sign refresh_token requests using it.
   email: string;
   scopes: string[]; // TODO use CLIENT_SCOPE type.
-  otp_id?: string;
-  otp?: string;
+}
+
+export interface OTPTokenRequest2 {
+  grant_type: 'otp';
+  public_key?: string;
+  scopes: string[]; // TODO use CLIENT_SCOPE type.
+  otp_id: string;
+  otp: string;
 }
 
 export interface ClientCredentialsTokenRequest {


### PR DESCRIPTION
Extend the API of dexie-cloud-addon to support parameters `otp` and `otpId` to db.cloud.login(). This can be used when OTP message links to the application with otp and otpId in the query so that the application can use it and auto-login user using these two parameters.
