### PR TITLE
Fix issue with BigInt64Array

### DIFF
--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -187,7 +187,7 @@ export function flatten<T> (a: (T | T[])[]) : T[] {
 
 //https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 const intrinsicTypeNames =
-    "Array,Boolean,String,Date,RegExp,Blob,File,FileList,FileSystemFileHandle,FileSystemDirectoryHandle,ArrayBuffer,DataView,Uint8ClampedArray,ImageBitmap,ImageData,Map,Set,CryptoKey"
+    "BigInt64Array,Array,Boolean,String,Date,RegExp,Blob,File,FileList,FileSystemFileHandle,FileSystemDirectoryHandle,ArrayBuffer,DataView,Uint8ClampedArray,ImageBitmap,ImageData,Map,Set,CryptoKey"
     .split(',').concat(
         flatten([8,16,32,64].map(num=>["Int","Uint","Float"].map(t=>t+num+"Array")))
     ).filter(t=>_global[t]);

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -473,6 +473,10 @@ promisedTest("Issue #1890 - BigInt64Array getting corrupted after an update", as
         ok(true, "BigInt64Array not supported in browser");
         return;
     }
+    if (typeof Dexie.Observable?.version === 'string') {
+        ok(true, "Skipping this test - Dexie.Observable bails out from BigInts");
+        return;
+    }
 
     await db.foo.put({
         id: 1,

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -474,7 +474,6 @@ promisedTest("Issue #1890 - BigInt64Array getting corrupted after an update", as
         return;
     }
 
-    debugger;
     await db.foo.put({
         id: 1,
         updated: Date.now(),

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -466,3 +466,27 @@ promisedTest("Issue - ReadonlyError thrown in liveQuery despite user did not do 
     `);
     return F(ok, equal, Dexie, db, liveQuery).catch(err => ok(false, 'final catch: '+err));
 });
+
+
+promisedTest("Issue #1890 - BigInt64Array getting corrupted after an update", async () => {
+    if (typeof BigInt64Array === 'undefined') {
+        ok(true, "BigInt64Array not supported in browser");
+        return;
+    }
+
+    debugger;
+    await db.foo.put({
+        id: 1,
+        updated: Date.now(),
+        cols: [{
+          values: new BigInt64Array([1n, 2n])
+        }]
+    });
+    let val = await db.foo.get(1);
+    ok(val.cols[0].values instanceof BigInt64Array, "cols[0].values is a BigInt64Array");
+    await db.foo.update(1, {
+        updated: Date.now()
+    });
+    val = await db.foo.get(1);
+    ok(val.cols[0].values instanceof BigInt64Array, "cols[0].values is still a BigInt64Array after update");
+});


### PR DESCRIPTION
Table.update() corrupts values of type BigInt64Array.

