### PR TITLE
Added SkipTables Option

### DIFF
--- a/addons/dexie-export-import/src/import.ts
+++ b/addons/dexie-export-import/src/import.ts
@@ -19,6 +19,7 @@ export interface ImportOptions extends StaticImportOptions {
   acceptChangedPrimaryKey?: boolean;
   overwriteValues?: boolean;
   clearTablesBeforeImport?: boolean;
+  skipTables?: string[],
   noTransaction?: boolean;
   chunkSizeBytes?: number; // Default: DEFAULT_KILOBYTES_PER_CHUNK ( 1MB )
   filter?: (table: string, value: any, key?: any) => boolean;
@@ -68,6 +69,7 @@ export async function importInto(db: Dexie, exportedData: Blob | JsonStream<Dexi
   const readBlobsSynchronously = 'FileReaderSync' in self; // true in workers only.
 
   const dbExport = dbExportFile.data!;
+  const skipTables = options.skipTables? options.skipTables: []
 
   if (!options!.acceptNameDiff && db.name !== dbExport.databaseName)
     throw new Error(`Name differs. Current database name is ${db.name} but export is ${dbExport.databaseName}`);
@@ -91,6 +93,7 @@ export async function importInto(db: Dexie, exportedData: Blob | JsonStream<Dexi
 
   if (options!.clearTablesBeforeImport) {
     for (const table of db.tables) {
+      if(skipTables.includes(table.name) ) continue;
       await table.clear();
     }
   }
@@ -104,6 +107,7 @@ export async function importInto(db: Dexie, exportedData: Blob | JsonStream<Dexi
   async function importAll () {
     do {
       for (const tableExport of dbExport.data) {
+        if(skipTables.includes(tableExport.tableName)) continue;
         if (!tableExport.rows) break; // Need to pull more!
         if (!(tableExport.rows as any).incomplete && tableExport.rows.length === 0)
           continue;


### PR DESCRIPTION
In my effort to properly convert dexie-encrypted to work with more complex scenarios,  I found the need to completely exclude tables from the import export process.  Mainly the encryption metadata.  

So I added the options into the project both import and export,  to simply skip the requested list of tables in all operations.  

I feel this is a good addition to round out the options for controlling the backups. 

It's backwards compatible and does nothing if not specified. 

Regards
Nick