### PR TITLE
Allow setting chunk size per table

### DIFF
--- a/src/classes/collection/collection.ts
+++ b/src/classes/collection/collection.ts
@@ -484,7 +484,15 @@ export class Collection implements ICollection {
 
       const coreTable = ctx.table.core;
       const {outbound, extractKey} = coreTable.schema.primaryKey;
-      const limit = this.db._options.modifyChunkSize || 200;
+      let limit = 200;
+      const modifyChunkSize = this.db._options.modifyChunkSize;
+      if (modifyChunkSize) {
+        if (typeof modifyChunkSize == 'object') {
+          limit = modifyChunkSize[coreTable.name] || modifyChunkSize['*'] || 200;
+        } else {
+          limit = modifyChunkSize;
+        }
+      }
       const totalFailures = [];
       let successCount = 0;
       const failedKeys: IndexableType[] = [];

--- a/src/public/types/dexie-constructor.d.ts
+++ b/src/public/types/dexie-constructor.d.ts
@@ -19,7 +19,7 @@ export interface DexieOptions {
   indexedDB?: {open: Function};
   IDBKeyRange?: {bound: Function, lowerBound: Function, upperBound: Function};
   allowEmptyDB?: boolean;
-  modifyChunkSize?: number;
+  modifyChunkSize?: number | { [key: string]: number };
   chromeTransactionDurability?: ChromeTransactionDurability;
   cache?: 'immutable' | 'cloned' | 'disabled';
 }


### PR DESCRIPTION
Single Database can have object stores with varying complexity and amount of data in them. Having one `modifyChunkSize` value may not be sufficient for all scenarios. 

This PR introduces an option to set `modifyChunkSize` per table.