### PR TITLE
CRDT for add/remove

### DIFF
--- a/addons/Dexie.Syncable/package.json
+++ b/addons/Dexie.Syncable/package.json
@@ -54,7 +54,7 @@
     ],
     "dexie-syncable": [
       "# Build UMD module and the tests (two bundles)",
-      "tsc --allowJs --moduleResolution node --lib es2015,dom -t es5 -m es2015 --outDir tools/tmp/es5 --rootDir ../.. --sourceMap src/Dexie.Syncable.js test/unit/unit-tests-all.js [--watch 'Compilation complete.']",
+      "tsc --allowJs --moduleResolution node --lib es2020,dom -t es5 -m es2015 --outDir tools/tmp/es5 --rootDir ../.. --sourceMap src/Dexie.Syncable.js test/unit/unit-tests-all.js [--watch 'Compilation complete.']",
       "rollup -c tools/build-configs/rollup.config.js",
       "rollup -c tools/build-configs/rollup.tests.config.js",
       "node tools/replaceVersionAndDate.js dist/dexie-syncable.js",

--- a/import-wrapper-prod.mjs
+++ b/import-wrapper-prod.mjs
@@ -7,6 +7,9 @@ const Dexie = globalThis[DexieSymbol] || (globalThis[DexieSymbol] = _Dexie);
 if (_Dexie.semVer !== Dexie.semVer) {
     throw new Error(`Two different versions of Dexie loaded in the same app: ${_Dexie.semVer} and ${Dexie.semVer}`);
 }
-const { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Entity, PropModSymbol, PropModification, replacePrefix } = Dexie;
-export { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Dexie, Entity, PropModSymbol, PropModification, replacePrefix };
+const {
+    liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Entity,
+    PropModSymbol, PropModification, replacePrefix, add, remove } = Dexie;
+export { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Dexie, Entity,
+    PropModSymbol, PropModification, replacePrefix, add, remove };
 export default Dexie;

--- a/import-wrapper.mjs
+++ b/import-wrapper.mjs
@@ -7,6 +7,8 @@ const Dexie = globalThis[DexieSymbol] || (globalThis[DexieSymbol] = _Dexie);
 if (_Dexie.semVer !== Dexie.semVer) {
     throw new Error(`Two different versions of Dexie loaded in the same app: ${_Dexie.semVer} and ${Dexie.semVer}`);
 }
-const { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Entity, PropModSymbol, PropModification, replacePrefix } = Dexie;
-export { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Dexie, Entity, PropModSymbol, PropModification, replacePrefix };
+const { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Entity,
+    PropModSymbol, PropModification, replacePrefix, add, remove } = Dexie;
+export { liveQuery, mergeRanges, rangesOverlap, RangeSet, cmp, Dexie, Entity,
+    PropModSymbol, PropModification, replacePrefix, add, remove };
 export default Dexie;

--- a/src/functions/propmods/add.ts
+++ b/src/functions/propmods/add.ts
@@ -1,0 +1,5 @@
+import { PropModification } from "../../helpers/prop-modification";
+
+export function add(value: number | BigInt | Array<string | number>) {
+  return new PropModification({add: value});
+}

--- a/src/functions/propmods/index.ts
+++ b/src/functions/propmods/index.ts
@@ -1,0 +1,3 @@
+export * from "./add";
+export * from "./remove";
+export * from "./replace-prefix";

--- a/src/functions/propmods/remove.ts
+++ b/src/functions/propmods/remove.ts
@@ -1,0 +1,5 @@
+import { PropModification } from "../../helpers/prop-modification";
+
+export function remove(value: number | BigInt | Array<string | number>) {
+  return new PropModification({remove: value});
+}

--- a/src/functions/propmods/replace-prefix.ts
+++ b/src/functions/propmods/replace-prefix.ts
@@ -1,4 +1,4 @@
-import { PropModification } from "../helpers/prop-modification";
+import { PropModification } from "../../helpers/prop-modification";
 
 export function replacePrefix(a: string, b:string) {
   return new PropModification({replacePrefix: [a, b]});

--- a/src/helpers/prop-modification.ts
+++ b/src/helpers/prop-modification.ts
@@ -1,12 +1,62 @@
+import { isArray } from "../functions/utils";
 import { PropModSpec } from "../public/types/prop-modification";
 
 export const PropModSymbol: unique symbol = Symbol();
 
+/** Consistent change propagation across offline synced data.
+ * 
+ * This class is executed client- and server side on sync, making
+ * an operation consistent across sync for full consistency and accuracy.
+ * 
+ * Example: An object represents a bank account with a balance.
+ * One offline user adds $ 1.00 to the balance.
+ * Another user (online) adds $ 2.00 to the balance.
+ * When first user syncs, the balance becomes the sum of every operation (3.00).
+ * 
+ * -- initial: balance is 0
+ * 1. db.bankAccounts.update(1, { balance: new ProdModification({add: 100})}) // user 1 (offline)
+ * 2. db.bankAccounts.update(1, { balance: new ProdModification({add: 200})}) // user 2 (online)
+ * -- before user 1 syncs, balance is 200 (representing money with integers * 100 to avoid rounding issues)
+ * <user 1 syncs>
+ * -- balance is 300
+ * 
+ * When new operations are added, they need to be added to:
+ * 1. PropModSpec interface
+ * 2. Here in PropModification with the logic they represent
+ * 3. (Optionally) a sugar function for it, such as const mathAdd = (amount: number | BigInt) => new PropModification({mathAdd: amount})
+ */
 export class PropModification implements PropModSpec {
   [PropModSymbol]?: true;
   replacePrefix?: [string, string];
+  add?: number | BigInt | Array<string | number>;
+  remove?: number | BigInt | Array<string | number>;
 
-  execute(value: any) {
+  execute(value: any): any {
+    // add (mathematical or set-wise)
+    if (this.add !== undefined) {
+      const term = this.add;
+      // Set-addition on array representing a set of primitive types (strings, numbers)
+      if (isArray(term)) {
+        return [...(isArray(value) ? value : []), ...term].sort();
+      }
+      // Mathematical addition:
+      if (typeof term === 'number') return Number(value) + term;
+      if (typeof term === 'bigint') return BigInt(value) + term;
+    }
+
+    // remove (mathematical or set-wise)
+    if (this.remove !== undefined) {
+      const subtrahend = this.remove;
+      // Set-addition on array representing a set of primitive types (strings, numbers)
+      if (isArray(subtrahend)) {
+        return isArray(value) ? value.filter(item => !subtrahend.includes(item)).sort() : [];
+      }        
+      // Mathematical addition:
+      if (typeof subtrahend === 'number') return Number(value) - subtrahend;
+      if (typeof subtrahend === 'bigint') return BigInt(value) - subtrahend;
+    }
+
+    // Replace a prefix:
     const prefixToReplace = this.replacePrefix?.[0];
     if (prefixToReplace && typeof value === 'string' && value.startsWith(prefixToReplace)) {
       return this.replacePrefix[1] + value.substring(prefixToReplace.length);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { liveQuery } from './live-query/live-query';
 import { Entity } from './classes/entity/Entity';
 import { cmp } from './functions/cmp';
 import { PropModification, PropModSymbol } from './helpers/prop-modification';
-import { replacePrefix } from './functions/replace-prefix';
+import { replacePrefix, add, remove } from './functions/propmods';
 
 
 // Set rejectionMapper of DexiePromise so that it generally tries to map
@@ -29,6 +29,6 @@ Debug.setDebug(Debug.debug, dexieStackFrameFilter);
 export { RangeSet, mergeRanges, rangesOverlap } from "./helpers/rangeset";
 export { Dexie, liveQuery }; // Comply with public/index.d.ts.
 export { Entity };
-export { cmp };
-export { PropModSymbol, PropModification, replacePrefix };
+export { cmp };
+export { PropModSymbol, PropModification, replacePrefix, add, remove };
 export default Dexie;

--- a/src/public/index.d.ts
+++ b/src/public/index.d.ts
@@ -65,6 +65,8 @@ export function rangesOverlap(
 declare var RangeSet: RangeSetConstructor;
 export function cmp(a: any, b: any): number;
 export function replacePrefix(a: string, b: string): PropModification;
+export function add(num: number | bigint | any[]): PropModification;
+export function remove(num: number | bigint | any[]): PropModification;
 
 /** Exporting 'Dexie' as the default export.
  **/

--- a/src/public/types/prop-modification.d.ts
+++ b/src/public/types/prop-modification.d.ts
@@ -2,11 +2,15 @@ export declare const PropModSymbol: unique symbol;
 
 export type PropModSpec = {
   replacePrefix?: [string, string];
+  add?: number | BigInt | Array<string | number>;
+  remove?: number | BigInt | Array<string | number>;
 }
 
 export class PropModification implements PropModSpec {
   [PropModSymbol]?: true;
   replacePrefix?: [string, string];
+  add?: number | BigInt | Array<string | number>;
+  remove?: number | BigInt | Array<string | number>;
 
   execute<T>(value: T): T;
 


### PR DESCRIPTION
* number or bigint properties (add/subtract)
* array properties (treating array as a set)

## Mathematical addition Example

```ts
import { add } from "dexie";
db.friends.update(1, {
  age: add(1)
});
// Equivalent to:
db.friends.update(1, friend => ++friend.age);
// ...but works consistently in sync
```

## Set addition Example

```ts
import { add } from "dexie";
db.friends.update(1, {
  interests: add(["football"])
});
// Equivalent to:
db.friends.update(1, friend => friend.interests = [...friend.interests, "football"].sort());
// ...but works consistently in sync
```

Checklist
 - [x] Unit tests
 - [x] Implementation
 - [ ] Support in Dexie Cloud Server (will automatically be supported when upgrading dexie dep of dexie-cloud)
 - [ ] Update documentation of Collection.modify()
 - [ ] Update documentation of Table.update()
 - [ ] Update documentation of Consistency in Dexie Cloud

