### PR TITLE
Fix #1969

### DIFF
--- a/addons/dexie-export-import/src/dexie-export-import.ts
+++ b/addons/dexie-export-import/src/dexie-export-import.ts
@@ -1,9 +1,9 @@
 import Dexie from 'dexie';
-import { ExportOptions, exportDB } from './export';
+import { ExportOptions, ExportProgress, exportDB } from './export';
 import { importDB, peakImportFile, ImportOptions, importInto, StaticImportOptions } from './import';
 import { DexieExportJsonMeta } from './json-structure';
 
-export { exportDB, ExportOptions};
+export { exportDB, ExportOptions, ExportProgress};
 export { importDB, importInto, peakImportFile, ImportOptions, DexieExportJsonMeta};
 
 //


### PR DESCRIPTION
This fixes #1969 (a type was not exported)


Note to myself and other people that want to test/contribute to dexie.js
1. Clone dexie.js, install pnpm (I used `nix-shell -p nodePackages.pnpm`, npm will not work here), and run `pnpm install` in the root folder of Dexie, `pnpm build` in the root folder to build dexie.js (not sure if needed for addons), and go to `addons/dexie-export-import/`, and also run these two commands. This should create a `dist` folder.
2. From the `addons/dexie-export-import/`, run `npm link`
3. From your project, run `npm link dexie-export-import`, it should make `node_modules/dexie-export-import` point (via a symlink) to your copy of dexie project. Everytime you change dexie, make sure to rebuild it.