### PR TITLE
Issue login without sync

### DIFF
--- a/addons/dexie-cloud/src/sync/connectWebSocket.ts
+++ b/addons/dexie-cloud/src/sync/connectWebSocket.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, from, Observable, of, throwError } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, from, Observable, of, throwError } from 'rxjs';
 import {
   catchError,
   debounceTime,
@@ -39,7 +39,7 @@ async function waitAndReconnectWhenUserDoesSomething(error: Error) {
   await sleep(3000);
   // Wait til user does something (move mouse, tap, scroll, click etc)
   console.debug('waiting for someone to do something');
-  await userDoesSomething.pipe(take(1)).toPromise();
+  await firstValueFrom(userDoesSomething);
   console.debug('someone did something!');
 }
 

--- a/addons/dexie-cloud/src/sync/messagesFromServerQueue.ts
+++ b/addons/dexie-cloud/src/sync/messagesFromServerQueue.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 import { DexieCloudDB } from '../db/DexieCloudDB';
 import { WSConnectionMsg } from '../WSObservable';
@@ -73,12 +73,11 @@ export function MessagesFromServerConsumer(db: DexieCloudDB) {
         // If the sync worker or service worker is syncing, wait 'til thei're done.
         // It's no need to have two channels at the same time - even though it wouldnt
         // be a problem - this is an optimization.
-        await db.cloud.syncState
-          .pipe(
-            filter(({ phase }) => phase === 'in-sync' || phase === 'error'),
-            take(1)
+        await firstValueFrom(
+          db.cloud.syncState.pipe(
+            filter(({ phase }) => phase === 'in-sync' || phase === 'error')
           )
-          .toPromise();
+        );
         console.debug('processing msg', msg);
         const persistedSyncState = db.cloud.persistedSyncState.value;
         //syncState.


### PR DESCRIPTION
An issue was reported privately that the following situation could occur:

1. Login prompt, enter email
2. OTP prompt enter OTP
3. Authentication happens
4. Sync starts
5. Web page is refreshed, aborting the sync call
6. Now, state could be authenticated but without any data from the realms that the user have access to - only from the public realm. Refreshing page again did not help. Only explicitely calling db.cloud.sync({purpuse: "pull"}) could resolve the state and download all data for the user.

The issue was that in connectWebSocket.ts, createObservable(), in case user is logged in, we're waiting with setting up the websocket until the user's sync call has completeted. Now if page was refreshed after login, but before sync call completed, the webSocket will wait there forever. We still want to wait there in case user is logged in so that we don't setup a websocket subscribing to public data only and then realize the realms have changed and reconnect socket.

So the solution I made was in dexie-cloud-client.ts, to treat this in-between-state as if user has been changed and thus trigger a sync with purpose "pull" (which means it should sync regardless if we have local changes or not).

*2nd commit: we also rewrite the deprecated `.toPromise()` method on Rx observables and use `firstValueFrom()` instead. We could also remove `take(1)` because firstValueFrom() will only take first emitted value anyway.*
