### PR TITLE
Fix missing idbtrans in transaction

### DIFF
--- a/src/public/types/transaction.d.ts
+++ b/src/public/types/transaction.d.ts
@@ -6,6 +6,7 @@ export interface Transaction {
   db: Dexie;
   active: boolean;
   mode: IDBTransactionMode;
+  idbtrans: IDBTransaction;
   //tables: { [type: string]: Table<any, any> }; Deprecated since 2.0. Obsolete from v3.0.
   storeNames: Array<string>;
   explicit?: boolean;


### PR DESCRIPTION
Typescript complains that idbtrans does not exist, even if the class actually defines it:
```
$ cat src/classes/transaction/transaction.ts
…
/** Transaction
 * 
 * https://dexie.org/docs/Transaction/Transaction
 * 
 **/
export class Transaction implements ITransaction {
…
  idbtrans: IDBTransaction;
…
```
This fixes this issue. Credit goes to https://stackoverflow.com/questions/78453173/typescript-pretents-foo-is-not-in-type-bar-while-it-is-how-to-debug/78453320#78453320