### PR TITLE
export ./dist/dexie.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "default": "./dist/dexie.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./dist/dexie.mjs": "./dist/dexie.mjs"
   },
   "typings": "dist/dexie.d.ts",
   "jspm": {


### PR DESCRIPTION
Makes importing `dexie/dist/dexie.mjs` not restricted by package.json `exports` field.

Refs #1995