### PR TITLE
Fix consistency for add()/remove() operations that are divided into chunks due to the number of rows being updated

### DIFF
--- a/addons/dexie-cloud/src/middlewares/createMutationTrackingMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/createMutationTrackingMiddleware.ts
@@ -265,6 +265,10 @@ export function createMutationTrackingMiddleware({
                       txid,
                       userId,
                     };
+
+              if ('isAdditionalChunk' in req && req.isAdditionalChunk) {
+                mut.isAdditionalChunk = true;
+              }
               return keys.length > 0 || ('criteria' in req && req.criteria)
                 ? mutsTable
                     .mutate({ type: 'add', trans, values: [mut] }) // Log entry

--- a/libs/dexie-cloud-common/package.json
+++ b/libs/dexie-cloud-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-common",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Library for shared code between dexie-cloud-addon, dexie-cloud (CLI) and dexie-cloud-server",
   "type": "module",
   "module": "dist/index.js",

--- a/libs/dexie-cloud-common/src/DBOperation.ts
+++ b/libs/dexie-cloud-common/src/DBOperation.ts
@@ -34,6 +34,7 @@ export interface DBOperationCommon<PK=DBOpPrimaryKey> {
   txid?: string | null;
   userId?: string | null;
   opNo?: number;
+  isAdditionalChunk?: boolean;
 }
 export interface DBInsertOperation<PK=DBOpPrimaryKey> extends DBOperationCommon<PK> {
   type: "insert";

--- a/src/public/types/dbcore.d.ts
+++ b/src/public/types/dbcore.d.ts
@@ -57,6 +57,7 @@ export interface DBCorePutRequest {
     range: DBCoreKeyRange;
   };
   changeSpec?: {[keyPath: string]: any}; // Common changeSpec for each key
+  isAdditionalChunk?: boolean;
   updates?: {
     keys: any[],
     changeSpecs: {[keyPath: string]: any}[]; // changeSpec per key.  
@@ -74,6 +75,7 @@ export interface DBCoreDeleteRequest {
     index: string | null;
     range: DBCoreKeyRange;
   };
+  isAdditionalChunk?: boolean;
 }
 
 export interface DBCoreDeleteRangeRequest {


### PR DESCRIPTION
When consistent modify/delete operations get chunked due to exceeding the default number of operations (200) in Collection.modify(), the additional chunks will now be flagged with with "isAdditionalChunk" so that consistent operations are never applied multiple times on the sync server.

We already make sure that if the where()...modify() operation results in zero matches locally, we still sync the operation to the server in case it would hit a result there, which could always be a possibility.

The thing we haven't taken care of is if the modify or delete operation resulted in multiple chunks into DBCore, resulting in multiple DBOperations synced to Dexie Cloud Server, the server did apply the condition and its updates multiple times. This is not an issue for idempotent operations such as adding to a set or deletions but mathematical add/subtract is not idempotent.

If a query such as: db.people.where('name').startsWith('A').modify({
  age: add(1)
});
...and there happens to be 1000 local people matching the criteria, those people would end up getting their age added not with 1 but with 5 if modifyChunkSize is 200 since the operation would result in 5 mutations of 200 each - all with criteria and changeSpec in them. When reaching the server, it would ignore the changes that the client computed and instead run the criteria on its database and execute the addition 5 times - one for each chunk. With this commit, all but the first chunk will be flagged with isAdditionalChunk=true, making the server only execute the consistent operation on the initial chunk and ignore the rest. However, the keys of the remaining chunks are still important information for server, so are the local results that came out from it.