### PR TITLE
add complete ./dist/* to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       }
     },
     "./package.json": "./package.json",
-    "./dist/dexie.mjs": "./dist/dexie.mjs"
+    "./dist/*": "./dist/*"
   },
   "typings": "dist/dexie.d.ts",
   "jspm": {


### PR DESCRIPTION
followup on #1997, but now declaring the complete `dist` folder as `exports` in `package.json`, so that you can import `dexie/dist/modern/dexie.mjs` to without getting these rollup / vite errors:

```
[plugin node-resolve] Could not resolve import "dexie/dist/modern/dexie.mjs" in [...] using exports defined in [...]/node_modules/dexie/package.json.
```