### PR TITLE
Resolve 2011

### DIFF
--- a/src/live-query/cache/cache-middleware.ts
+++ b/src/live-query/cache/cache-middleware.ts
@@ -149,7 +149,8 @@ export const cacheMiddleware: Middleware<DBCore> = {
             if (
               primKey.outbound || // Non-inbound tables are harded to apply optimistic updates on because we can't know primary key of results
               trans.db._options.cache === 'disabled' || // User has opted-out from caching
-              trans.explicit // It's an explicit write transaction being made. Don't affect cache until transaction commits.
+              trans.explicit || // It's an explicit write transaction being made. Don't affect cache until transaction commits.
+              trans.idbtrans.mode !== 'readwrite' // We only handle 'readwrite' in our transaction override. 'versionchange' transactions don't use cache (from populate or upgraders).
             ) {
               // Just forward the request to the core.
               return downTable.mutate(req);


### PR DESCRIPTION
#2011 was another bug than #2012.

Its repro uses on.on('populate') to add objects.

Bug: The 'populate' event executes within 'versionchange' transaction and not normal 'readwrite' transaction.

Our cache is implemented using [Dexie.use()](https://dexie.org/docs/Dexie/Dexie.use()) middleware that overriders "transaction", "mutate" and "query".

The result was that our "mutate" override added the optimistic updates but the "transaction" override didn't follow up on these optimistic updates when the transaction settled because it only follows up on "readwrite" transactions so it left them hanging there forever.
