### PR TITLE
Cmp instead of idb

### DIFF
--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -148,7 +148,7 @@ export class Table implements ITable<any, IndexableType> {
     const idb = this.db._deps.indexedDB;
 
     function equals (a, b) {
-      return idb.cmp(a,b) === 0; // Works with all indexable types including binary keys.
+      return cmp(a, b); // Works with all indexable types including binary keys.
     }
 
     const [idx, filterFunction] = keyPaths.reduce(([prevIndex, prevFilterFn], keyPath) => {

--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -146,8 +146,9 @@ export class Table implements ITable<any, IndexableType> {
     // and filter the rest.
     const { idxByName } = this.schema;
     const idb = this.db._deps.indexedDB;
-    function equals (a, b) {
-      return cmp(a, b); // Works with all indexable types including binary keys.
+
+    function equals(a, b) {
+      return cmp(a, b) === 0; // Works with all indexable types including binary keys.
     }
 
     const [idx, filterFunction] = keyPaths.reduce(([prevIndex, prevFilterFn], keyPath) => {

--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -145,7 +145,6 @@ export class Table implements ITable<any, IndexableType> {
     // Ok, now let's fallback to finding at least one matching index
     // and filter the rest.
     const { idxByName } = this.schema;
-    const idb = this.db._deps.indexedDB;
 
     function equals(a, b) {
       return cmp(a, b) === 0; // Works with all indexable types including binary keys.

--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -146,7 +146,6 @@ export class Table implements ITable<any, IndexableType> {
     // and filter the rest.
     const { idxByName } = this.schema;
     const idb = this.db._deps.indexedDB;
-
     function equals (a, b) {
       return cmp(a, b); // Works with all indexable types including binary keys.
     }


### PR DESCRIPTION
This PR aims to fix issue #2064 
What I've changed is basically the comparison function, from idb.cmp() to cmp() defined at src/functions/cmp.ts