### PR TITLE
Fix Multiple Image Blob Export

### DIFF
--- a/addons/dexie-export-import/package.json
+++ b/addons/dexie-export-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-export-import",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Dexie addon that adds export and import capabilities",
   "main": "dist/dexie-export-import.js",
   "module": "dist/dexie-export-import.mjs",

--- a/addons/dexie-export-import/src/tson.ts
+++ b/addons/dexie-export-import/src/tson.ts
@@ -77,5 +77,6 @@ TSON.finalize = async (items?: any[]) => {
     }
   }
   // Free up memory
-  // blobsToAwait = [];
+  blobsToAwait = [];
+  blobsToAwaitPos = 0;
 }

--- a/addons/dexie-export-import/src/tson.ts
+++ b/addons/dexie-export-import/src/tson.ts
@@ -70,12 +70,12 @@ TSON.finalize = async (items?: any[]) => {
           const typeSpec = TSON.types[typeName];
           if (typeSpec && typeSpec.finalize) {
             const b = Dexie.getByKeyPath(item, arrayType ? "$." + keyPath : keyPath);
-            typeSpec.finalize(b, allChunks.slice(b.start, b.end));
+            typeSpec.finalize(b, allChunks.slice(b.data?.start, b.data?.end));
           }
         }
       }
     }
   }
   // Free up memory
-  blobsToAwait = [];
+  // blobsToAwait = [];
 }

--- a/addons/dexie-export-import/test/basic-tests.ts
+++ b/addons/dexie-export-import/test/basic-tests.ts
@@ -61,19 +61,25 @@ promisedTest("export-format", async() => {
   for (let i=0;i<256;++i) {
     fullByteArray[i] = i;
   }
+  const blob1 = new Blob(["1"])
+  const blob2 = new Blob(["2"])
+  const blob3 = new Blob(["3"])
   await db.table("inbound").bulkAdd([{
     id: 1,
     date: new Date(1),
     fullBlob: new Blob([fullByteArray]),
+    imageBlob: blob1,
     binary: new Uint8Array([1,2,3]),
     text: "foo",
     bool: false
   },{
     id: 2,
-    foo: "bar"
+    foo: "bar",
+    imageBlob: blob2,
   },{
     id: 3,
-    bar: "foo"
+    bar: "foo",
+    imageBlob: blob3,
   }]);
 
   const blob = await db.export({prettyJson: true});
@@ -98,6 +104,19 @@ promisedTest("export-format", async() => {
   const ba = new Uint8Array(ab);
   console.log("byte array", ba);
   deepEqual([].slice.call(ba), [].slice.call(fullByteArray), "The whole byte spectrum supported after redecoding blob");
+  
+  const blob1A = await blob1.text()
+  const blob1B = await inboundValues[0].imageBlob.text()
+  deepEqual( blob1A, blob1B, "First Blob should be same as stored");
+
+  const blob2A = await blob2.text()
+  const blob2B = await inboundValues[1].imageBlob.text()
+  deepEqual( blob2A, blob2B, "Second Blob should be same as stored");
+
+  const blob3A = await blob3.text()
+  const blob3B = await inboundValues[2].imageBlob.text()
+  deepEqual( blob3A, blob3B, "Third Blob should be same as stored");
+  
   equal( stringBlob, "something", "First Blob should be 'something'");
   equal( inboundValues[0].binary[0], 1, "First binary[0] should be 1");
   equal( inboundValues[0].binary[1], 2, "First binary[0] should be 2");

--- a/addons/dexie-export-import/test/basic-tests.ts
+++ b/addons/dexie-export-import/test/basic-tests.ts
@@ -84,6 +84,8 @@ promisedTest("export-format", async() => {
   await db.delete();
   const importedDB = await Dexie.import(blob);
   const outboundKeys = await importedDB.table('outbound').toCollection().primaryKeys();
+  const outboundValues = await importedDB.table('outbound').toArray();
+  const stringBlob = await readBlob(outboundValues[1].blob)
   const inboundValues = await importedDB.table('inbound').toArray();
   equal (outboundKeys[0], 2, "First key should be 2");
   ok('getTime' in (outboundKeys[1] as Date), "Second outbound key should be a Date instance");
@@ -96,7 +98,7 @@ promisedTest("export-format", async() => {
   const ba = new Uint8Array(ab);
   console.log("byte array", ba);
   deepEqual([].slice.call(ba), [].slice.call(fullByteArray), "The whole byte spectrum supported after redecoding blob");
-  //equal(firstBlobStr, "something", "First Blob should be 'something'");
+  equal( stringBlob, "something", "First Blob should be 'something'");
   equal( inboundValues[0].binary[0], 1, "First binary[0] should be 1");
   equal( inboundValues[0].binary[1], 2, "First binary[0] should be 2");
   equal( inboundValues[0].binary[2], 3, "First binary[0] should be 3");

--- a/addons/dexie-export-import/test/tools.ts
+++ b/addons/dexie-export-import/test/tools.ts
@@ -17,23 +17,11 @@ export function promisedTest(name: string, tester: ()=>Promise<any>) {
 }
 
 export function readBlob(blob: Blob): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onabort = ev => reject(new Error("file read aborted"));
-    reader.onerror = ev => reject((ev.target as any).error);
-    reader.onload = ev => resolve((ev.target as any).result);
-    reader.readAsText(blob);
-  });
+  return blob.text();
 }
 
 export function readBlobBinary(blob: Blob): Promise<ArrayBuffer> {
-  return new Promise<ArrayBuffer>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onabort = ev => reject(new Error("file read aborted"));
-    reader.onerror = ev => reject((ev.target as any).error);
-    reader.onload = ev => resolve((ev.target as any).result);
-    reader.readAsArrayBuffer(blob);
-  });
+  return blob.arrayBuffer();
 }
 
 // Must use this rather than QUnit's deepEqual() because that one fails on Safari when run via karma-browserstack-launcher


### PR DESCRIPTION
Hello there, I'm the developer of [noto.ooo](https://noto.ooo/) and have been enjoying using Dexie and dexie-export-import as part of this project!

[I've **re-discovered a bug** that I believe surfaced in this pull request](https://github.com/dexie/Dexie.js/pull/1271).
With hopes of fixing this for my own project and to give a little back to this fantastic library I've done my best to put together the following pull request.

**Case:** When storing multiple Blobs with Dexie, exporting the database with dexie-export-import, then importing that exported database.

**Expected Behaviour:** I see each of my images displayed.

**Actual Behaviour:** I see the first of my many images repeated for as many images as there are.

## Reproduction of this Bug
I noticed this issue with a new feature I'm developing where images are stored and exported/imported with Dexie and dexie-export-import.

In order to make the issue clearly demonstrable I've put together a sample project:
- [CodeSandbox](https://codesandbox.io/p/github/chrigglesby/dexie-blob-export-test/main)
- [CodeSandbox App Demo](https://gmhq3j-3000.csb.app/)
- [Sample Project Repository](https://github.com/chrigglesby/dexie-blob-export-test/tree/main)

### Reproduction Steps with Sample Project

| Step | Screenshot |
| --- | --- |
| [Go to Sample Project App](https://gmhq3j-3000.csb.app/) |<img width="830" alt="image" src="https://github.com/user-attachments/assets/5a1a0286-194d-4abf-ac22-0d96b1a3c00a">|
| Save the provided sample images |<img width="645" alt="image" src="https://github.com/user-attachments/assets/4a2551a0-1180-4df2-bb7a-18251a1e0b28">|
| Upload and Add each of the sample images |<img width="392" alt="image" src="https://github.com/user-attachments/assets/2e144233-f90c-4f82-9366-ab52a44d948d">|
| |<img width="52" alt="image" src="https://github.com/user-attachments/assets/50b55467-6cd9-4c55-a466-10ccac0c28ca">|
| |<img width="536" alt="image" src="https://github.com/user-attachments/assets/958f70d0-3157-4611-8ec9-b776d516b53e">|
| |<img width="534" alt="image" src="https://github.com/user-attachments/assets/530865c6-0cbb-442b-8455-92d5a17e172d">|
| Now there are three distinct images in the database, they are rendered on the page (separately from the sample images) |<img width="762" alt="image" src="https://github.com/user-attachments/assets/1f12fcdf-e131-4dd6-ae1f-b22c95a1c290">|
| Export and Save |<img width="69" alt="image" src="https://github.com/user-attachments/assets/4b569fe9-5196-4cef-a4e2-aea8ff014a53">|
| Import the Exported file |<img width="242" alt="image" src="https://github.com/user-attachments/assets/242358f0-7ecf-46cc-82e9-09edde03ad13">|
| You'll see the issue - After importing, the rendered images now show only the first of the three images |<img width="830" alt="image" src="https://github.com/user-attachments/assets/a1ea472c-2d05-4abd-9b17-f527758e328d">|

## Fix Approach
As I mentioned, I searched for an existing issue for this and [found this existing and closed issue](https://github.com/dexie/Dexie.js/pull/1271). I was curious if this fix worked so pasted it directly into my project's (noto) `node_modules/dexie-export-import/dist/dexie-export-import.mjs`. Where I had been exporting and importing a large amount of images and being perplexed as to why the same image was repeated for every single one, after applying this patch and exporting/importing again I could verify that my images were displaying as I expected.

### Updating the Test
I noticed the other PR was closed due a test failing so thought I had better try and address that.

- I added more blobs to the test to see that multiple blobs will induce the bug
- I then applied the fix and see that the tests pass

### Testing
I've tested that this fix solves my outlined problem, exporting the same image over and over.

**Test Case Anecdotes**
- Initially copy pasting the fix into my node_modules
- Checking out Dexie/dexie-export-import and symlinking to my project (noto)
  - without fix, bug occurs
  - apply fix, build, see expected results
- Building a sample bug reproduction project, symlinking to node_modules
  - without fix, bug occurs
  - apply fix, build, see expected results

## Closing
Thanks for your continued work and passion on this incredibly valuable library - love it! ❤️
Although I'm a touch out of my depth diving into this unknown codebase, I'm motivated to get this issue fixed and have done my best to make a solid pull request to that end.