### PR TITLE
Create a library for a reactive Dexie.js query in Svelte 5

### DIFF
--- a/libs/dexie-svelte-query/.gitignore
+++ b/libs/dexie-svelte-query/.gitignore
@@ -1,0 +1,4 @@
+# Output
+/.svelte-kit
+/dist
+

--- a/libs/dexie-svelte-query/.npmrc
+++ b/libs/dexie-svelte-query/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/libs/dexie-svelte-query/README.md
+++ b/libs/dexie-svelte-query/README.md
@@ -1,0 +1,30 @@
+# Dexis Svelte Query
+
+Svelte reactive state query for fetching using Dexie.js
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { stateQuery } from 'dexie-svelte-query';
+	import { db } from './db';
+
+	let minAge = $state(18);
+	let maxAge = $state(65);
+
+	const friendsQuery = stateQuery(
+		() => db.friends.where('age').between(minAge, maxAge).toArray(),
+		() => [minAge, maxAge]
+	);
+	let friends = $derived(friendsQuery.current);
+</script>
+
+<div>
+	<h2>Friends</h2>
+	<ul>
+		{#each friends ?? [] as friend (friend.id)}
+			<li>{friend.name}, {friend.age}</li>
+		{/each}
+		</ul>
+</div>
+```

--- a/libs/dexie-svelte-query/package.json
+++ b/libs/dexie-svelte-query/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "dexie-svelte-query",
+	"version": "1.0.0",
+	"description": "Svelte reactive state query for fetching using Dexie.js",
+	"author": "Oliver Dowling (https://github.com/oliverdowling)",
+	"scripts": {
+		"build": "pnpm run package",
+		"package": "svelte-package && publint",
+		"prepublishOnly": "pnpm run package",
+		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
+	},
+	"files": [
+		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*"
+	],
+	"svelte": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	},
+	"peerDependencies": {
+		"dexie": "^3.2 || ^4.0.1",
+		"svelte": "^5.0.0"
+	},
+	"devDependencies": {
+		"@sveltejs/package": "^2.3.7",
+		"dexie": "^4.0.10",
+		"publint": "^0.3.0",
+		"svelte": "^5.17.1",
+		"svelte-check": "^4.1.3",
+		"typescript": "^5.7.3"
+	}
+}

--- a/libs/dexie-svelte-query/src/lib/index.ts
+++ b/libs/dexie-svelte-query/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./stateQuery.svelte.js";

--- a/libs/dexie-svelte-query/src/lib/stateQuery.svelte.ts
+++ b/libs/dexie-svelte-query/src/lib/stateQuery.svelte.ts
@@ -1,0 +1,17 @@
+import { liveQuery } from "dexie";
+
+export function stateQuery<T>(
+	querier: () => T | Promise<T>,
+	dependencies?: () => unknown[]
+): { current?: T } {
+	const query = $state<{ current?: T }>({ current: undefined });
+	$effect(() => {
+		dependencies?.();
+		return liveQuery(querier).subscribe((result) => {
+			if (result !== undefined) {
+				query.current = result;
+			}
+		}).unsubscribe;
+	});
+	return query;
+}

--- a/libs/dexie-svelte-query/tsconfig.json
+++ b/libs/dexie-svelte-query/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext"
+	}
+}


### PR DESCRIPTION
I put the code from issue #2075 into a Svelte library.

I just used [`sv create`](https://svelte.dev/docs/cli/sv-create) and stripped it down a bit.