### PR TITLE
Fix Named Export 'Dexie' Not Found in Production with Vite/Vinxi

### DIFF
--- a/libs/dexie-react-hooks/src/useLiveQuery.ts
+++ b/libs/dexie-react-hooks/src/useLiveQuery.ts
@@ -1,4 +1,4 @@
-import { liveQuery } from 'dexie';
+import Dexie from 'dexie';
 import { useObservable } from './useObservable';
 
 export function useLiveQuery<T>(
@@ -16,7 +16,7 @@ export function useLiveQuery<T, TDefault>(
   defaultResult?: TDefault
 ): T | TDefault {
   return useObservable(
-    () => liveQuery(querier),
+    () => Dexie.liveQuery(querier),
     deps || [],
     defaultResult as TDefault
   );


### PR DESCRIPTION
## Issue Description
When using dexie-react-hooks with TanStack Start (which uses Vinxi/Vite), the production build fails with the error "Named export 'Dexie' not found". This occurs due to an ESM/CommonJS interoperability issue in the production build process, while development mode works correctly.

## Root Cause
The issue stems from how dexie-react-hooks imports Dexie and how Vite/Vinxi handles these imports in production mode. The current package configuration doesn't properly handle the dual ESM/CommonJS nature of the Dexie import when bundled in production.

Fixes: https://github.com/dexie/Dexie.js/issues/2153
