### PR TITLE
fix: 'Dexie' Not Found in Production with Vite/Vinxi dexie-react-hooks

### DIFF
--- a/libs/dexie-react-hooks/src/usePermissions.ts
+++ b/libs/dexie-react-hooks/src/usePermissions.ts
@@ -1,4 +1,4 @@
-import { Dexie } from 'dexie';
+import Dexie from 'dexie';
 import { useObservable } from './useObservable';
 //import type { KeyPaths, TableProp } from 'dexie'; // Issue #1725 - not compatible with dexie@3.
 // Workaround: provide these types inline for now. When dexie 4 stable is out, we can use the types from dexie@4.


### PR DESCRIPTION
When using dexie-react-hooks with TanStack Start (which uses Vinxi/Vite), the production build fails with the error "Named export 'Dexie' not found". This occurs due to an ESM/CommonJS interoperability issue in the production build process, while development mode works correctly.