### PR TITLE
Feature: Table.upsert()

### DIFF
--- a/libs/dexie-cloud-common/package.json
+++ b/libs/dexie-cloud-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-common",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Library for shared code between dexie-cloud-addon, dexie-cloud (CLI) and dexie-cloud-server",
   "type": "module",
   "module": "dist/index.js",

--- a/libs/dexie-cloud-common/src/DBOperation.ts
+++ b/libs/dexie-cloud-common/src/DBOperation.ts
@@ -44,6 +44,7 @@ export interface DBInsertOperation<PK=DBOpPrimaryKey> extends DBOperationCommon<
 export interface DBUpsertOperation<PK=DBOpPrimaryKey> extends DBOperationCommon<PK> {
   type: "upsert";
   values: readonly any[];
+  changeSpecs?: ({ [keyPath: string]: any } | null)[];
 }
 
 export interface DBUpdateOperation<PK=DBOpPrimaryKey> extends DBOperationCommon<PK> {

--- a/src/functions/apply-update-spec.ts
+++ b/src/functions/apply-update-spec.ts
@@ -1,0 +1,24 @@
+import { getByKeyPath, keys, setByKeyPath } from './utils';
+import { PropModification } from "../helpers/prop-modification";
+
+export function applyUpdateSpec(
+  obj: any,
+  changes: { [keyPath: string]: any }
+): boolean {
+  const keyPaths = keys(changes);
+  const numKeys = keyPaths.length;
+  let anythingModified = false;
+  for (let i = 0; i < numKeys; ++i) {
+    const keyPath = keyPaths[i];
+    const value = changes[keyPath];
+    const origValue = getByKeyPath(obj, keyPath);
+    if (value instanceof PropModification) {
+      setByKeyPath(obj, keyPath, value.execute(origValue));
+      anythingModified = true;
+    } else if (origValue !== value) {
+      setByKeyPath(obj, keyPath, value); // Adding {keyPath: undefined} means that the keyPath should be deleted. Handled by setByKeyPath
+      anythingModified = true;
+    }
+  }
+  return anythingModified;
+}

--- a/src/public/types/dbcore.d.ts
+++ b/src/public/types/dbcore.d.ts
@@ -52,6 +52,7 @@ export interface DBCorePutRequest {
   values: readonly any[];
   keys?: any[];
   mutatedParts?: ObservabilitySet
+  upsert?: boolean; // If true, will insert the object if it does not exist. If false, will only update existing objects using the 'updates' property.
   criteria?: {
     index: string | null;
     range: DBCoreKeyRange;

--- a/src/public/types/table.d.ts
+++ b/src/public/types/table.d.ts
@@ -46,6 +46,9 @@ export interface Table<T=any, TKey=any, TInsertType=T> {
   update(
     key: TKey | T,
     changes: UpdateSpec<TInsertType> | ((obj: T, ctx:{value: any, primKey: IndexableType}) => void | boolean)): PromiseExtended<number>;
+  upsert(
+    key: TKey | T,
+    changes: UpdateSpec<TInsertType>): PromiseExtended<boolean>;
   put(item: TInsertType, key?: TKey): PromiseExtended<TKey>;
   delete(key: TKey): PromiseExtended<void>;
   clear(): PromiseExtended<void>;


### PR DESCRIPTION
As prematurely documented on the website: https://dexie.org/docs/Table/Table.upsert()

We need this for realm creation on sharing. Recommendations of creating realms from boundRealmId will be updated in docs to use Table.upsert() instead of Table.put() - since Table.put() replaces the existing owner of the realm while Table.upsert() only makes sure to get the object created with some props but leaving owner property unchanged.