### PR TITLE
feat: useSuspendingLiveQuery

### DIFF
--- a/libs/dexie-react-hooks/src/dexie-react-hooks.ts
+++ b/libs/dexie-react-hooks/src/dexie-react-hooks.ts
@@ -2,3 +2,5 @@ export * from './useLiveQuery';
 export * from './useObservable';
 export * from './usePermissions';
 export * from './useDocument';
+export * from './useSuspendingLiveQuery';
+export * from './useSuspendingObservable';

--- a/libs/dexie-react-hooks/src/useSuspendingLiveQuery.ts
+++ b/libs/dexie-react-hooks/src/useSuspendingLiveQuery.ts
@@ -10,5 +10,8 @@ export function useSuspendingLiveQuery<T>(
   querier: () => Promise<T> | T,
   cacheKey: React.DependencyList
 ): T {
-  return useSuspendingObservable(() => Dexie.liveQuery(querier), cacheKey);
+  return useSuspendingObservable(
+    () => Dexie.liveQuery(querier),
+    ['dexie', ...cacheKey]
+  );
 }

--- a/libs/dexie-react-hooks/src/useSuspendingLiveQuery.ts
+++ b/libs/dexie-react-hooks/src/useSuspendingLiveQuery.ts
@@ -1,0 +1,14 @@
+import { Dexie } from 'dexie';
+import { useSuspendingObservable } from './useSuspendingObservable';
+
+/**
+ * Observe IndexedDB data in your React component. Make the component re-render when the observed data changes.
+ *
+ * Suspends until first value is available.
+ */
+export function useSuspendingLiveQuery<T>(
+  querier: () => Promise<T> | T,
+  cacheKey: React.DependencyList
+): T {
+  return useSuspendingObservable(() => Dexie.liveQuery(querier), cacheKey);
+}

--- a/libs/dexie-react-hooks/src/useSuspendingObservable.ts
+++ b/libs/dexie-react-hooks/src/useSuspendingObservable.ts
@@ -14,36 +14,71 @@ export function useSuspendingObservable<T>(
   getObservable: () => InteropableObservable<T>,
   cacheKey: React.DependencyList
 ): T {
-  let observable = memoized(OBSERVABLE_CACHE, cacheKey, getObservable);
-  const firstValue = useSuspendingPromise(
-    () => getFirstValue(observable),
-    [observable]
-  );
-  return useObservableValue(observable, firstValue);
-}
+  let observable: InteropableObservable<T> | undefined;
+  // TODO: enable iterators in TS and remove Array.from
+  for (const [key, val] of Array.from(OBSERVABLES.entries())) {
+    if (
+      cacheKey.length === key.length &&
+      cacheKey.every((x, i) => x === key[i])
+    ) {
+      observable = val;
+      break;
+    }
+  }
+  if (!observable) {
+    observable = getObservable();
+    OBSERVABLES.set(cacheKey, observable);
+  }
 
-const OBSERVABLE_CACHE = new Map<
-  React.DependencyList,
-  InteropableObservable<any>
->();
-
-/**
- * Returns a promise that resolves with the first value emitted by the observable.
- */
-function getFirstValue<T>(observable: InteropableObservable<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const sub = observable.subscribe(
-      (v) => {
-        resolve(v);
-        unsub(sub);
-      },
-      (err) => {
-        reject(err);
-        unsub(sub);
+  let promise: Promise<T> | undefined = PROMISES.get(observable);
+  if (!promise) {
+    promise = new Promise<T>((resolve, reject) => {
+      if (VALUES.has(observable)) {
+        resolve(VALUES.get(observable)!);
+        return;
       }
+      const sub = observable.subscribe(
+        (val) => {
+          resolve(val);
+          VALUES.set(observable, val);
+          unsub(sub);
+          PROMISES.delete(observable);
+        },
+        (err) => {
+          reject(err);
+          unsub(sub);
+          PROMISES.delete(observable);
+        }
+      );
+    });
+    PROMISES.set(observable, promise);
+  }
+
+  use(promise);
+
+  const [value, setValue] = React.useState<T>(VALUES.get(observable));
+  const [error, setError] = React.useState<any>(null);
+
+  React.useEffect(() => {
+    const sub = observable.subscribe(
+      (val) => {
+        VALUES.set(observable, val);
+        setValue(val);
+      },
+      (err) => setError(err)
     );
-  });
+    return () => unsub(sub);
+  }, [observable]);
+
+  if (error) throw error;
+  return value;
 }
+
+const OBSERVABLES = new Map<React.DependencyList, InteropableObservable<any>>();
+
+const PROMISES = new WeakMap<InteropableObservable<any>, Promise<any>>();
+
+const VALUES = new WeakMap<InteropableObservable<any>, any>();
 
 /** Unsubscribes from an observable */
 function unsub(sub: (() => unknown) | { unsubscribe: () => unknown }) {
@@ -52,82 +87,4 @@ function unsub(sub: (() => unknown) | { unsubscribe: () => unknown }) {
   } else {
     sub.unsubscribe();
   }
-}
-
-/**
- * Returns the result of a promise.
- * Suspends until the promise is resolved.
- *
- * Calls with the same cacheKey will use the same promise until it resolves.
- * After that, the promise is removed from the cache after 1 second.
- *
- * cacheKey must be globally unique.
- */
-export function useSuspendingPromise<T>(
-  getPromise: () => Promise<T>,
-  cacheKey: React.DependencyList
-): T {
-  let promise = memoized(PROMISE_CACHE, cacheKey, () =>
-    getPromise().finally(() => {
-      setTimeout(() => {
-        PROMISE_CACHE.delete(cacheKey);
-      }, 1000);
-    })
-  );
-  return use(promise);
-}
-
-const PROMISE_CACHE = new Map<React.DependencyList, Promise<any>>();
-
-/**
- * Returns a value from the `cache` using the specified `key`.
- * If the key does not exist, the `init` function is called to create the value,
- * which is then stored in the cache and returned.
- *
- * The key is compared using dependency list semantics (like React.useEffect).
- */
-function memoized<T>(
-  cache: Map<React.DependencyList, T>,
-  key: React.DependencyList,
-  init: () => T
-): T {
-  let val: T | undefined;
-  // TODO: enable iterators in TS and remove Array.from
-  for (const [k, v] of Array.from(cache.entries())) {
-    if (depEq(k, key)) {
-      val = v;
-      break;
-    }
-  }
-  if (!val) {
-    val = init();
-    cache.set(key, val);
-  }
-  return val;
-}
-
-/** Compares two React dependency lists for equality */
-function depEq(a: React.DependencyList, b: React.DependencyList): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (!Object.is(a[i], b[i])) return false;
-  }
-  return true;
-}
-
-/**
- * Subscribes to an observable and returns the current latest value.
- *
- * Does not suspend, instead uses the provided initialValue until the first value is received.
- */
-function useObservableValue<T>(
-  observable: InteropableObservable<T>,
-  initialValue: T
-): T {
-  const [value, setValue] = React.useState(initialValue);
-  React.useEffect(() => {
-    const sub = observable.subscribe((v) => setValue(v));
-    return () => unsub(sub);
-  }, [observable]);
-  return value;
 }

--- a/libs/dexie-react-hooks/src/useSuspendingObservable.ts
+++ b/libs/dexie-react-hooks/src/useSuspendingObservable.ts
@@ -1,0 +1,133 @@
+import React from 'react';
+import { InteropableObservable } from './useObservable';
+
+const use = (React as any).use as <T>(promise: Promise<T>) => T;
+
+/**
+ * Subscribes to an observable and returns the latest value.
+ * Suspends until the first value is received.
+ *
+ * Calls with the same cacheKey will use the same observable.
+ * cacheKey must be globally unique.
+ */
+export function useSuspendingObservable<T>(
+  getObservable: () => InteropableObservable<T>,
+  cacheKey: React.DependencyList
+): T {
+  let observable = memoized(OBSERVABLE_CACHE, cacheKey, getObservable);
+  const firstValue = useSuspendingPromise(
+    () => getFirstValue(observable),
+    [observable]
+  );
+  return useObservableValue(observable, firstValue);
+}
+
+const OBSERVABLE_CACHE = new Map<
+  React.DependencyList,
+  InteropableObservable<any>
+>();
+
+/**
+ * Returns a promise that resolves with the first value emitted by the observable.
+ */
+function getFirstValue<T>(observable: InteropableObservable<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const sub = observable.subscribe(
+      (v) => {
+        resolve(v);
+        unsub(sub);
+      },
+      (err) => {
+        reject(err);
+        unsub(sub);
+      }
+    );
+  });
+}
+
+/** Unsubscribes from an observable */
+function unsub(sub: (() => unknown) | { unsubscribe: () => unknown }) {
+  if (typeof sub === 'function') {
+    sub();
+  } else {
+    sub.unsubscribe();
+  }
+}
+
+/**
+ * Returns the result of a promise.
+ * Suspends until the promise is resolved.
+ *
+ * Calls with the same cacheKey will use the same promise until it resolves.
+ * After that, the promise is removed from the cache after 1 second.
+ *
+ * cacheKey must be globally unique.
+ */
+export function useSuspendingPromise<T>(
+  getPromise: () => Promise<T>,
+  cacheKey: React.DependencyList
+): T {
+  let promise = memoized(PROMISE_CACHE, cacheKey, () =>
+    getPromise().finally(() => {
+      setTimeout(() => {
+        PROMISE_CACHE.delete(cacheKey);
+      }, 1000);
+    })
+  );
+  return use(promise);
+}
+
+const PROMISE_CACHE = new Map<React.DependencyList, Promise<any>>();
+
+/**
+ * Returns a value from the `cache` using the specified `key`.
+ * If the key does not exist, the `init` function is called to create the value,
+ * which is then stored in the cache and returned.
+ *
+ * The key is compared using dependency list semantics (like React.useEffect).
+ */
+function memoized<T>(
+  cache: Map<React.DependencyList, T>,
+  key: React.DependencyList,
+  init: () => T
+): T {
+  let val: T | undefined;
+  // TODO: enable iterators in TS and remove Array.from
+  for (const [k, v] of Array.from(cache.entries())) {
+    if (depEq(k, key)) {
+      val = v;
+      break;
+    }
+  }
+  if (!val) {
+    val = init();
+    cache.set(key, val);
+  }
+  return val;
+}
+
+/** Compares two React dependency lists for equality */
+function depEq(a: React.DependencyList, b: React.DependencyList): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!Object.is(a[i], b[i])) return false;
+  }
+  return true;
+}
+
+/**
+ * Subscribes to an observable and returns the current latest value.
+ *
+ * Does not suspend, instead uses the provided initialValue until the first value is received.
+ */
+function useObservableValue<T>(
+  observable: InteropableObservable<T>,
+  initialValue: T
+): T {
+  const [value, setValue] = React.useState(initialValue);
+  React.useEffect(() => {
+    const sub = observable.subscribe((v) => setValue(v));
+    return () => unsub(sub);
+  }, [observable]);
+  return value;
+}

--- a/libs/dexie-react-hooks/test/components/ItemListComponent.tsx
+++ b/libs/dexie-react-hooks/test/components/ItemListComponent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLiveQuery } from "../../src";
+import { useSuspendingLiveQuery } from "../../src";
 import { Item } from "../models/Item";
 import { ItemComponent } from "./ItemComponent";
 
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export function ItemListComponent({ loadItems }: Props) {
-  const items = useLiveQuery(loadItems);
+  const items = useSuspendingLiveQuery(loadItems, []);
   if (!items) return <p>Loading...</p>;
   return (
     <>


### PR DESCRIPTION
Implemented suspending hook similar to https://github.com/dexie/Dexie.js/discussions/1276#discussioncomment-8411915

Right now it never clears the caches. I couldn't think of a simple way to implement it.

I had in mind the latest changes in Observable spec which say that observables are always hot (shared) and there is no way to detect new subscriber from observable side. This means that it's impossible to implement a BehaviorSubject which emits last value for each new subscriber. That's why I'm keeping the last value in memory for each observable. Even this is not perfect because if you pass an observable to the hook and also use it somewhere else then the first value could be missed.

I will upload an example app later which uses this so you can test it.