### PR TITLE
fix(dexie-cloud): Optimize and harden runtime Blob Resolving

### DIFF
--- a/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
@@ -206,11 +206,15 @@ function createBlobResolvingCursor(
   // throws "Illegal invocation" in Chrome 146+.
   const wrappedCursor = Object.create(cursor, {
     key: {
-      get() { return cursor.key; },
+      get() {
+        return cursor.key;
+      },
       configurable: true,
     },
     primaryKey: {
-      get() { return cursor.primaryKey; },
+      get() {
+        return cursor.primaryKey;
+      },
       configurable: true,
     },
     value: {

--- a/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
@@ -328,23 +328,18 @@ function resolveAndSave(
               : undefined;
 
         if (key !== undefined) {
-          // Queue each resolved blob individually for atomic update
-          // This uses setTimeout(fn, 0) to completely isolate from
-          // Dexie's transaction context (avoids inheriting PSD)
-          if (isReadonly) {
-            blobSavingQueue.saveBlobs(table.name, key, resolvedBlobs);
-          } else {
-            // For rw transactions, we can save directly without queueing
-            // since we're still in the same transaction context
-            table
-              .mutate({ type: 'put', keys: [key], values: [resolved], trans })
-              .catch((err) => {
-                console.error(
-                  `Failed to save resolved blob on ${table.name}:${key}:`,
-                  err
-                );
-              });
-          }
+          // Always use the BlobSavingQueue, even for rw transactions.
+          // Reason: blob download is an async native fetch that breaks out of
+          // Dexie's PSD zone. By the time the download finishes, PSD.trans is
+          // no longer the original transaction (it may be undefined or a
+          // different transaction). Calling table.mutate() at that point causes
+          // HooksMiddleware to read PSD.trans, crash, and surface the error as
+          // "[dexie-cloud:blobResolve] Failed to resolve BlobRefs on <table>".
+          //
+          // BlobSavingQueue uses setTimeout(fn, 0) to run in a fresh JS task
+          // completely outside any PSD context, then opens a proper Dexie rw
+          // transaction — which is always safe regardless of the calling context.
+          blobSavingQueue.saveBlobs(table.name, key, resolvedBlobs);
         }
 
         return resolved;

--- a/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/blobResolveMiddleware.ts
@@ -8,10 +8,11 @@
  * Uses Dexie.waitFor() only for explicit rw transactions to keep them alive.
  * For readonly or implicit transactions, resolves directly (no waitFor needed).
  *
- * Resolved blobs are queued for saving via BlobSavingQueue, which uses
- * setTimeout(fn, 0) to completely isolate from Dexie's transaction context.
- * Each blob is saved atomically using Table.update() with its keyPath to
- * avoid race conditions with other property changes.
+ * Resolved blobs are persisted via db.blobDownloadTracker.enqueueSave(),
+ * which internally uses a queue that runs in a fresh JS task to completely
+ * isolate from Dexie's transaction context. Each blob is saved atomically
+ * using Table.update() with its keyPath to avoid race conditions with other
+ * property changes.
  *
  * Blob downloads use Authorization header (same as sync) via the server
  * proxy endpoint: GET /blob/{ref}
@@ -34,7 +35,6 @@ import {
   resolveAllBlobRefs,
   ResolvedBlob,
 } from '../sync/blobResolve';
-import { BlobSavingQueue } from '../sync/BlobSavingQueue';
 import { TXExpandos } from '../types/TXExpandos';
 import { UserLogin } from '../dexie-cloud-client';
 
@@ -46,9 +46,6 @@ export function createBlobResolveMiddleware(
     name: 'blobResolve',
     level: 2, // Run above cache (0) and other middlewares (1) to resolve BlobRefs from cached data
     create(downlevelDatabase: DBCore): DBCore {
-      // Create a single queue instance for this database
-      const blobSavingQueue = new BlobSavingQueue(db);
-
       return {
         ...downlevelDatabase,
         table(tableName: string): DBCoreTable {
@@ -82,7 +79,6 @@ export function createBlobResolveMiddleware(
                     req.trans,
                     req.key,
                     result,
-                    blobSavingQueue,
                     db
                   );
                 }
@@ -112,7 +108,6 @@ export function createBlobResolveMiddleware(
                         req.trans,
                         req.keys[index],
                         result,
-                        blobSavingQueue,
                         db
                       );
                     }
@@ -147,7 +142,6 @@ export function createBlobResolveMiddleware(
                         req.trans,
                         undefined,
                         item,
-                        blobSavingQueue,
                         db
                       );
                     }
@@ -168,12 +162,7 @@ export function createBlobResolveMiddleware(
                 if (!cursor) return cursor; // No results, so no resolution needed
                 if (!req.values) return cursor; // No values requested, so no resolution needed
                 if (!dbUrl) return cursor; // No database URL configured, can't resolve blobs
-                return createBlobResolvingCursor(
-                  cursor,
-                  downlevelTable,
-                  blobSavingQueue,
-                  db
-                );
+                return createBlobResolvingCursor(cursor, downlevelTable, db);
               });
             },
           };
@@ -196,7 +185,6 @@ export function createBlobResolveMiddleware(
 function createBlobResolvingCursor(
   cursor: DBCoreCursor,
   table: DBCoreTable,
-  blobSavingQueue: BlobSavingQueue,
   db: DexieCloudDB
 ): DBCoreCursor {
   // Create wrapped cursor using Object.create() - inherits everything.
@@ -237,7 +225,6 @@ function createBlobResolvingCursor(
             cursor.trans,
             cursor.primaryKey,
             rawValue,
-            blobSavingQueue,
             db,
             true
           ).then(
@@ -280,7 +267,6 @@ function resolveAndSave(
   trans: DBCoreTransaction,
   pKey: any | undefined, // optional. If missing, tries to extract from object using primary key path
   obj: any,
-  blobSavingQueue: BlobSavingQueue,
   db: DexieCloudDB,
   isCursorValue: boolean = false // Flag to indicate if we're resolving a cursor value (which may not have a primary key)
 ): Promise<any> {
@@ -332,18 +318,18 @@ function resolveAndSave(
               : undefined;
 
         if (key !== undefined) {
-          // Always use the BlobSavingQueue, even for rw transactions.
-          // Reason: blob download is an async native fetch that breaks out of
-          // Dexie's PSD zone. By the time the download finishes, PSD.trans is
-          // no longer the original transaction (it may be undefined or a
-          // different transaction). Calling table.mutate() at that point causes
-          // HooksMiddleware to read PSD.trans, crash, and surface the error as
-          // "[dexie-cloud:blobResolve] Failed to resolve BlobRefs on <table>".
-          //
-          // BlobSavingQueue uses setTimeout(fn, 0) to run in a fresh JS task
-          // completely outside any PSD context, then opens a proper Dexie rw
-          // transaction — which is always safe regardless of the calling context.
-          blobSavingQueue.saveBlobs(table.name, key, resolvedBlobs);
+          // Hand off persistence to the tracker. The tracker owns an
+          // internal save-queue that runs in a fresh JS task (setTimeout 0)
+          // — completely outside any PSD context, so opening a Dexie rw
+          // transaction there is always safe regardless of the calling
+          // context. The tracker also keeps the in-flight download cache
+          // alive until the save completes, so concurrent readers piggyback
+          // on the already-downloaded data instead of refetching.
+          db.blobDownloadTracker.enqueueSave(table.name, key, resolvedBlobs);
+        } else if (resolvedBlobs.length > 0) {
+          // No primary key — we can't persist. Release the in-flight cache
+          // entries explicitly so they don't leak.
+          db.blobDownloadTracker.releaseRefs(resolvedBlobs.map((b) => b.ref));
         }
 
         return resolved;

--- a/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
+++ b/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
@@ -1,27 +1,64 @@
 import type { DexieCloudDB } from '../db/DexieCloudDB';
-import { BlobRef } from './blobResolve';
+import { BlobRef, ResolvedBlob } from './blobResolve';
+import { BlobSavingQueue } from './BlobSavingQueue';
 import { loadCachedAccessToken } from './loadCachedAccessToken';
 
 /**
- * Deduplicates in-flight blob downloads.
+ * Owns the full lifecycle of downloaded blobs:
+ *   1. Deduplicates concurrent downloads for the same ref.
+ *   2. Bounds the number of concurrent network fetches (MAX_CONCURRENT)
+ *      so that ad-hoc reads can't starve the HTTP connection pool. Calls
+ *      beyond the cap queue in FIFO order as slots free. The slot is held
+ *      only for the duration of the fetch — NOT until persistence — to
+ *      avoid deadlocks when a single object contains more blob refs than
+ *      MAX_CONCURRENT (a sequential resolver would otherwise hold every
+ *      slot itself while waiting for the next).
+ *   3. Keeps the in-flight promise alive after the network fetch completes,
+ *      until the blob has been persisted back to IndexedDB. This way,
+ *      readers that ask for the same ref while it is queued for saving
+ *      can piggyback on the existing promise instead of refetching.
+ *      In-flight membership and slot ownership are independent: a piggyback
+ *      reader consumes neither a slot nor extra memory beyond the existing
+ *      cached Uint8Array.
+ *   4. Persists resolved blobs via an internal BlobSavingQueue, and
+ *      releases the in-flight entry when persistence completes.
  *
- * Both the blob-resolve middleware and the eager blob downloader may
- * try to fetch the same blob concurrently. This tracker ensures each
- * unique blob ref is only downloaded once — subsequent requests for
- * the same ref piggyback on the existing promise.
- *
- * Instantiate once per DexieCloudDB.
+ * Both the blob-resolve middleware and the eager blob downloader use this
+ * tracker. Instantiate once per DexieCloudDB.
  */
+
+const MAX_CONCURRENT = 6;
+
 export class BlobDownloadTracker {
   private inFlight = new Map<string, Promise<Uint8Array>>();
   private db: DexieCloudDB;
+  private savingQueue: BlobSavingQueue;
+  private activeFetches = 0;
+  private waiting: Array<() => void> = [];
 
   constructor(db: DexieCloudDB) {
     this.db = db;
+    this.savingQueue = new BlobSavingQueue(db, (refs) => {
+      // Called by the queue when a save transaction has completed
+      // (regardless of success). Drop the in-flight cache entries now —
+      // any future reader will go through IndexedDB instead.
+      for (const ref of refs) {
+        this.inFlight.delete(ref);
+      }
+    });
   }
 
   /**
-   * Download a blob, deduplicating concurrent requests for the same ref.
+   * Download a blob, deduplicating concurrent requests for the same ref
+   * and respecting the global fetch concurrency cap.
+   *
+   * Lifecycle:
+   *   - Slot is acquired before the fetch and released as soon as the
+   *     fetch settles (success or failure).
+   *   - The in-flight entry survives a successful fetch and lives on
+   *     until persistence completes (via enqueueSave) or releaseRefs
+   *     is called. On fetch failure, the entry is removed immediately
+   *     so a future call can retry.
    *
    * @param blobRef - The BlobRef to download
    * @param dbUrl - Base URL for the database (e.g., 'https://mydb.dexie.cloud')
@@ -29,13 +66,63 @@ export class BlobDownloadTracker {
   download(blobRef: BlobRef, dbUrl: string): Promise<Uint8Array> {
     let promise = this.inFlight.get(blobRef.ref);
     if (!promise) {
-      promise = this.downloadBlob(blobRef, dbUrl).finally(() =>
-        this.inFlight.delete(blobRef.ref)
-      );
-      // When the promise settles (either fulfilled or rejected), remove it from the in-flight map
+      promise = this.acquireSlot()
+        .then(() =>
+          this.downloadBlob(blobRef, dbUrl).finally(() => this.releaseSlot())
+        )
+        .catch((err) => {
+          // On error, remove immediately so a future call can retry.
+          // (Slot already released by the .finally above.)
+          this.inFlight.delete(blobRef.ref);
+          throw err;
+        });
       this.inFlight.set(blobRef.ref, promise);
     }
     return promise;
+  }
+
+  /**
+   * Queue resolved blobs for persisting back to IndexedDB.
+   * When the save transaction completes, the corresponding in-flight
+   * entries are released.
+   */
+  enqueueSave(
+    tableName: string,
+    primaryKey: any,
+    resolvedBlobs: ResolvedBlob[]
+  ): void {
+    this.savingQueue.saveBlobs(tableName, primaryKey, resolvedBlobs);
+  }
+
+  /**
+   * Release in-flight entries without going through the internal saving
+   * queue. Used when the caller persists the blobs itself (e.g., the
+   * eager downloader does its own table.update()), or when no primary
+   * key was available and the data won't be persisted at all.
+   */
+  releaseRefs(refs: string[]): void {
+    for (const ref of refs) {
+      this.inFlight.delete(ref);
+    }
+  }
+
+  private acquireSlot(): Promise<void> {
+    if (this.activeFetches < MAX_CONCURRENT) {
+      this.activeFetches++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiting.push(() => {
+        this.activeFetches++;
+        resolve();
+      });
+    });
+  }
+
+  private releaseSlot(): void {
+    this.activeFetches--;
+    const next = this.waiting.shift();
+    if (next) next();
   }
 
   /**

--- a/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
+++ b/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
@@ -27,7 +27,17 @@ import { loadCachedAccessToken } from './loadCachedAccessToken';
  * tracker. Instantiate once per DexieCloudDB.
  */
 
-const MAX_CONCURRENT = 6;
+/**
+ * Maximum number of concurrent blob fetches.
+ *
+ * Historically 6 to match the HTTP/1.1 same-origin connection cap that
+ * browsers enforce. With HTTP/2 (the typical transport for Dexie Cloud
+ * today) many streams multiplex over a single TCP connection, so the
+ * old cap is overly conservative. 10 is a modest bump that still keeps
+ * memory pressure (in-flight Uint8Arrays) and server load bounded.
+ * Can be made configurable via DexieCloudOptions if a real need arises.
+ */
+export const MAX_CONCURRENT = 10;
 
 export class BlobDownloadTracker {
   private inFlight = new Map<string, Promise<Uint8Array>>();
@@ -95,10 +105,23 @@ export class BlobDownloadTracker {
   }
 
   /**
+   * Wait until all previously enqueued saves have been persisted to
+   * IndexedDB. Used by callers that need to make decisions based on
+   * on-disk state — e.g., the eager downloader looping over rows with
+   * `_hasBlobRefs=1` in chunks, where each iteration must see the
+   * previous chunk's writes before re-querying.
+   *
+   * New saves enqueued AFTER drainPendingSaves() is called do NOT extend
+   * the wait.
+   */
+  drainPendingSaves(): Promise<void> {
+    return this.savingQueue.drain();
+  }
+
+  /**
    * Release in-flight entries without going through the internal saving
-   * queue. Used when the caller persists the blobs itself (e.g., the
-   * eager downloader does its own table.update()), or when no primary
-   * key was available and the data won't be persisted at all.
+   * queue. Used when the caller persists the blobs itself, or when no
+   * primary key was available and the data won't be persisted at all.
    */
   releaseRefs(refs: string[]): void {
     for (const ref of refs) {

--- a/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
+++ b/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
@@ -172,7 +172,14 @@ export class BlobDownloadTracker {
       // downloadBlob will omit the Authorization header when token is null.
       headers['Authorization'] = `Bearer ${accessToken}`;
     }
-    const response = await fetch(downloadUrl, { headers });
+    // cache: 'no-store' prevents the browser from storing this response in its
+    // HTTP cache. The server sets a long Expires/Cache-Control header on blob
+    // responses (blobs are immutable and content-addressed), which would
+    // otherwise cause the browser to keep a copy in its disk cache in addition
+    // to the copy we persist to IndexedDB — doubling storage for every blob.
+    // Since we always persist to IndexedDB and subsequent reads go through
+    // IndexedDB (never re-fetch), the browser cache copy is pure overhead.
+    const response = await fetch(downloadUrl, { headers, cache: 'no-store' });
 
     if (!response.ok) {
       throw new Error(

--- a/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
+++ b/addons/dexie-cloud/src/sync/BlobDownloadTracker.ts
@@ -29,50 +29,48 @@ export class BlobDownloadTracker {
   download(blobRef: BlobRef, dbUrl: string): Promise<Uint8Array> {
     let promise = this.inFlight.get(blobRef.ref);
     if (!promise) {
-      promise = loadCachedAccessToken(this.db)
-        .then((accessToken) => {
-          // accessToken may be null for anonymous/unauthenticated users.
-          // Public realm blobs (rlm-public) are accessible without auth.
-          // downloadBlob will omit the Authorization header when token is null.
-          return downloadBlob(blobRef, dbUrl, accessToken);
-        })
-        .finally(() => this.inFlight.delete(blobRef.ref));
+      promise = this.downloadBlob(blobRef, dbUrl).finally(() =>
+        this.inFlight.delete(blobRef.ref)
+      );
       // When the promise settles (either fulfilled or rejected), remove it from the in-flight map
       this.inFlight.set(blobRef.ref, promise);
     }
     return promise;
   }
-}
-/**
- * Download blob data from server via proxy endpoint.
- * Uses auth header for authentication (same as sync).
- * When accessToken is null, the request is made without Authorization header —
- * this allows downloading blobs from public realms (rlm-public) for
- * unauthenticated users.
- *
- * @param blobRef - The BlobRef to download
- * @param dbUrl - Base URL for the database (e.g., 'https://mydb.dexie.cloud')
- * @param accessToken - Access token for authentication, or null for anonymous access
- */
 
-export async function downloadBlob(
-  blobRef: BlobRef,
-  dbUrl: string,
-  accessToken: string | null
-): Promise<Uint8Array> {
-  const downloadUrl = `${dbUrl}/blob/${blobRef.ref}`;
-  const headers: HeadersInit = {};
-  if (accessToken) {
-    headers['Authorization'] = `Bearer ${accessToken}`;
+  /**
+   * Download blob data from server via proxy endpoint.
+   * Uses auth header for authentication (same as sync).
+   * When accessToken is null, the request is made without Authorization header —
+   * this allows downloading blobs from public realms (rlm-public) for
+   * unauthenticated users.
+   *
+   * @param blobRef - The BlobRef to download
+   * @param dbUrl - Base URL for the database (e.g., 'https://mydb.dexie.cloud')
+   */
+
+  private async downloadBlob(
+    blobRef: BlobRef,
+    dbUrl: string
+  ): Promise<Uint8Array> {
+    const accessToken = await loadCachedAccessToken(this.db);
+    const downloadUrl = `${dbUrl}/blob/${blobRef.ref}`;
+    const headers: HeadersInit = {};
+    if (accessToken) {
+      // accessToken may be null for anonymous/unauthenticated users.
+      // Public realm blobs (rlm-public) are accessible without auth.
+      // downloadBlob will omit the Authorization header when token is null.
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+    const response = await fetch(downloadUrl, { headers });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download blob ${blobRef.ref}: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return new Uint8Array(arrayBuffer);
   }
-  const response = await fetch(downloadUrl, { headers });
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download blob ${blobRef.ref}: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const arrayBuffer = await response.arrayBuffer();
-  return new Uint8Array(arrayBuffer);
 }

--- a/addons/dexie-cloud/src/sync/BlobSavingQueue.ts
+++ b/addons/dexie-cloud/src/sync/BlobSavingQueue.ts
@@ -82,27 +82,36 @@ export class BlobSavingQueue {
         for (const blob of item.resolvedBlobs) {
           updateSpec[blob.keyPath] = blob.data;
         }
-        tx.table(item.tableName).update(item.primaryKey, (obj) => {
-          // Check that object still has the same unresolved blob refs before applying update (i.e. it hasn't been modified since we read it)
-          for (const blob of item.resolvedBlobs) {
-            // Verify atomicity - none of the blob properties has been modified since we read it. If any of them was modified, skip updating this item to avoid overwriting user changes.
-            const currentValue = Dexie.getByKeyPath(obj, blob.keyPath);
-            if (currentValue === undefined) {
-              // Blob property was removed - skip updating this blob
-              continue;
+        tx.table(item.tableName)
+          .update(item.primaryKey, (obj) => {
+            // Check that object still has the same unresolved blob refs before applying update (i.e. it hasn't been modified since we read it)
+            for (const blob of item.resolvedBlobs) {
+              // Verify atomicity - none of the blob properties has been modified since we read it. If any of them was modified, skip updating this item to avoid overwriting user changes.
+              const currentValue = Dexie.getByKeyPath(obj, blob.keyPath);
+              if (currentValue === undefined) {
+                // Blob property was removed - skip updating this blob
+                continue;
+              }
+              if (!isBlobRef(currentValue)) {
+                // Blob property was modified to a non-blob-ref value - skip updating this blob
+                continue;
+              }
+              if (currentValue.ref !== blob.ref) {
+                // Blob property was modified - skip updating this blob
+                return; // Stop. Another items has been queued to fully fix the object.
+              }
+              Dexie.setByKeyPath(obj, blob.keyPath, blob.data);
             }
-            if (!isBlobRef(currentValue)) {
-              // Blob property was modified to a non-blob-ref value - skip updating this blob
-              continue;
-            }
-            if (currentValue.ref !== blob.ref) {
-              // Blob property was modified - skip updating this blob
-              return; // Stop. Another items has been queued to fully fix the object.
-            }
-            Dexie.setByKeyPath(obj, blob.keyPath, blob.data);
-          }
-          delete obj._hasBlobRefs; // Clear the _hasBlobRefs marker if all refs was resolved.
-        });
+            delete obj._hasBlobRefs; // Clear the _hasBlobRefs marker if all refs was resolved.
+          })
+          .then(() => {
+            // Disable waking up live queries since this is an internal update that shouldn't trigger UI updates.
+            // What we want is to clear out mutatedParts just before the transaction completes,
+            // but there is no hook for "just before transaction completes". So we do it in a then() after the update,
+            // which is guaranteed to run before the transaction completes and wakes up live queries.
+            // (doing it after transaction promise completes would be too late since live queries would have been woken up already)
+            trans.mutatedParts = undefined;
+          });
       })
       .catch((error) => {
         console.error(

--- a/addons/dexie-cloud/src/sync/BlobSavingQueue.ts
+++ b/addons/dexie-cloud/src/sync/BlobSavingQueue.ts
@@ -29,6 +29,7 @@ export class BlobSavingQueue {
   private isProcessing = false;
   private db: DexieCloudDB;
   private onPersisted: (refs: string[]) => void;
+  private drainResolvers: Array<() => void> = [];
 
   constructor(db: DexieCloudDB, onPersisted: (refs: string[]) => void) {
     this.db = db;
@@ -50,6 +51,26 @@ export class BlobSavingQueue {
       resolvedBlobs,
     });
     this.startConsumer();
+  }
+
+  /**
+   * Returns a promise that resolves when the queue is empty AND no item
+   * is currently being processed. Used by callers that need to know when
+   * all previously enqueued saves have been persisted to IndexedDB before
+   * making decisions based on the on-disk state (e.g., the eager blob
+   * downloader looping over `_hasBlobRefs=1` rows in chunks).
+   *
+   * Note: New work enqueued AFTER drain() is called does NOT extend the
+   * wait. Callers that race against concurrent producers should treat the
+   * returned promise as "queue was empty at some point after this call".
+   */
+  drain(): Promise<void> {
+    if (!this.isProcessing && this.queue.length === 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.drainResolvers.push(resolve);
+    });
   }
 
   /**
@@ -78,6 +99,14 @@ export class BlobSavingQueue {
     const item = this.queue.shift();
     if (!item) {
       this.isProcessing = false;
+      // Fire any pending drain() waiters. New saveBlobs() calls that
+      // arrive after this point will start a fresh processing cycle
+      // and have their own drain() semantics.
+      const resolvers = this.drainResolvers;
+      if (resolvers.length > 0) {
+        this.drainResolvers = [];
+        for (const resolve of resolvers) resolve();
+      }
       return;
     }
 
@@ -92,36 +121,32 @@ export class BlobSavingQueue {
         for (const blob of item.resolvedBlobs) {
           updateSpec[blob.keyPath] = blob.data;
         }
-        tx.table(item.tableName)
-          .update(item.primaryKey, (obj) => {
-            // Check that object still has the same unresolved blob refs before applying update (i.e. it hasn't been modified since we read it)
-            for (const blob of item.resolvedBlobs) {
-              // Verify atomicity - none of the blob properties has been modified since we read it. If any of them was modified, skip updating this item to avoid overwriting user changes.
-              const currentValue = Dexie.getByKeyPath(obj, blob.keyPath);
-              if (currentValue === undefined) {
-                // Blob property was removed - skip updating this blob
-                continue;
-              }
-              if (!isBlobRef(currentValue)) {
-                // Blob property was modified to a non-blob-ref value - skip updating this blob
-                continue;
-              }
-              if (currentValue.ref !== blob.ref) {
-                // Blob property was modified - skip updating this blob
-                return; // Stop. Another items has been queued to fully fix the object.
-              }
-              Dexie.setByKeyPath(obj, blob.keyPath, blob.data);
+        tx.table(item.tableName).update(item.primaryKey, (obj) => {
+          // Check that object still has the same unresolved blob refs before applying update (i.e. it hasn't been modified since we read it)
+          for (const blob of item.resolvedBlobs) {
+            // Verify atomicity - none of the blob properties has been modified since we read it. If any of them was modified, skip updating this item to avoid overwriting user changes.
+            const currentValue = Dexie.getByKeyPath(obj, blob.keyPath);
+            if (currentValue === undefined) {
+              // Blob property was removed - skip updating this blob
+              continue;
             }
-            delete obj._hasBlobRefs; // Clear the _hasBlobRefs marker if all refs was resolved.
-          })
-          .then(() => {
-            // Disable waking up live queries since this is an internal update that shouldn't trigger UI updates.
-            // What we want is to clear out mutatedParts just before the transaction completes,
-            // but there is no hook for "just before transaction completes". So we do it in a then() after the update,
-            // which is guaranteed to run before the transaction completes and wakes up live queries.
-            // (doing it after transaction promise completes would be too late since live queries would have been woken up already)
-            trans.mutatedParts = undefined;
-          });
+            if (!isBlobRef(currentValue)) {
+              // Blob property was modified to a non-blob-ref value - skip updating this blob
+              continue;
+            }
+            if (currentValue.ref !== blob.ref) {
+              // Blob property was modified - skip updating this blob
+              return; // Stop. Another items has been queued to fully fix the object.
+            }
+            Dexie.setByKeyPath(obj, blob.keyPath, blob.data);
+          }
+          delete obj._hasBlobRefs; // Clear the _hasBlobRefs marker if all refs was resolved.
+        });
+        // Note: we intentionally do NOT clear trans.mutatedParts here.
+        // Letting the normal mutation signal through means the
+        // blobProgress liveQuery (and any user-defined liveQuery that
+        // depends on the resolved fields) wakes up and reflects progress
+        // as blobs land in IndexedDB.
       })
       .catch((error) => {
         console.error(

--- a/addons/dexie-cloud/src/sync/BlobSavingQueue.ts
+++ b/addons/dexie-cloud/src/sync/BlobSavingQueue.ts
@@ -1,5 +1,9 @@
 /**
- * BlobSavingQueue - Queues resolved blobs for saving back to IndexedDB
+ * BlobSavingQueue - Queues resolved blobs for saving back to IndexedDB.
+ *
+ * This is an internal collaborator of BlobDownloadTracker and is not
+ * intended to be used directly by middleware or other code. See
+ * BlobDownloadTracker.enqueueSave().
  *
  * Uses setTimeout(fn, 0) instead of queueMicrotask to completely isolate
  * from Dexie's Promise.PSD context. This prevents the save operation
@@ -24,9 +28,11 @@ export class BlobSavingQueue {
   private queue: QueuedBlob[] = [];
   private isProcessing = false;
   private db: DexieCloudDB;
+  private onPersisted: (refs: string[]) => void;
 
-  constructor(db: DexieCloudDB) {
+  constructor(db: DexieCloudDB, onPersisted: (refs: string[]) => void) {
     this.db = db;
+    this.onPersisted = onPersisted;
   }
 
   /**
@@ -38,7 +44,11 @@ export class BlobSavingQueue {
     primaryKey: any,
     resolvedBlobs: ResolvedBlob[]
   ): void {
-    this.queue.push({ tableName, primaryKey, resolvedBlobs });
+    this.queue.push({
+      tableName,
+      primaryKey,
+      resolvedBlobs,
+    });
     this.startConsumer();
   }
 
@@ -120,6 +130,13 @@ export class BlobSavingQueue {
         );
       })
       .finally(() => {
+        // At this point, the transaction has completed (either successfully or with error),
+        // and the blobs have been saved (or failed to save).
+        // Notify the owner (BlobDownloadTracker) so it can release the
+        // in-flight download cache entries for these refs. The cache was
+        // kept alive until now to maximize reuse while the blob was still
+        // in-flight (downloading or queued for save).
+        this.onPersisted(item.resolvedBlobs.map((b) => b.ref));
         // Process next item in the queue
         return this.processQueue();
       });

--- a/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
+++ b/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
@@ -4,34 +4,40 @@
  * Downloads unresolved blobs in the background when blobMode='eager'.
  * Called after sync completes to prefetch blobs for offline access.
  *
+ * Strategy: simply read rows with `_hasBlobRefs=1` in chunks via the
+ * normal middleware stack. The blob-resolve middleware does all the
+ * actual work — downloading blobs (throttled and deduplicated by the
+ * shared BlobDownloadTracker) and enqueueing them for persistence via
+ * the internal save queue. Between chunks we drain the save queue so
+ * the next chunk's query no longer sees the just-persisted rows.
+ *
+ * This keeps a single, symmetric code path with normal application
+ * reads, which is important when other middlewares are present
+ * (e.g., a hypothetical encryption middleware): writes from the save
+ * queue and reads from this loop both pass through the full middleware
+ * stack, so on-disk representation stays consistent.
+ *
  * Progress is tracked automatically via liveQuery in blobProgress.ts —
  * no manual progress reporting needed here.
  */
 
-import Dexie, { UpdateSpec } from 'dexie';
 import { BehaviorSubject } from 'rxjs';
-import { TSONRef, hasTSONRefs } from 'dexie-cloud-common';
-import {
-  BlobRef,
-  isBlobRef,
-  hasBlobRefs,
-  hasUnresolvedBlobRefs,
-  isSerializedTSONRef,
-  resolveAllBlobRefs,
-  ResolvedBlob,
-} from './blobResolve';
-import { loadCachedAccessToken } from './loadCachedAccessToken';
+import Dexie from 'dexie';
 import { setDownloadingState } from './blobProgress';
 import { DexieCloudDB } from '../db/DexieCloudDB';
 import { getSyncableTables } from '../helpers/getSyncableTables';
+import { MAX_CONCURRENT } from './BlobDownloadTracker';
+
+// One chunk = one full saturation of the tracker's concurrency semaphore.
+// Larger chunks would only buffer more downloaded Uint8Arrays in memory
+// while waiting for the save queue to persist them, without any throughput
+// benefit (the semaphore is the gate, not the query).
+const CHUNK_SIZE = MAX_CONCURRENT;
 
 /**
  * Download all unresolved blobs in the background.
  *
  * This is called when blobMode='eager' (default) after sync completes.
- * BlobRef URLs are signed (SAS tokens) so no auth header needed.
- *
- * Each blob is saved atomically using Table.update() to avoid race conditions.
  */
 export async function downloadUnresolvedBlobs(
   db: DexieCloudDB,
@@ -42,14 +48,14 @@ export async function downloadUnresolvedBlobs(
 
   debugLog('Eager download: Starting...');
 
-  // Scan for unresolved blobs
-  const syncedTables = getSyncableTables(db);
-  let hasWork = false;
+  const syncedTables = getSyncableTables(db).filter((t) =>
+    t.schema.indexes.some((idx) => idx.name === '_hasBlobRefs')
+  );
 
+  // Quick check: any work at all?
+  let hasWork = false;
   for (const table of syncedTables) {
     try {
-      const hasIndex = !!table.schema.idxByName['_hasBlobRefs'];
-      if (!hasIndex) continue;
       const count = await table.where('_hasBlobRefs').equals(1).count();
       if (count > 0) {
         hasWork = true;
@@ -69,109 +75,88 @@ export async function downloadUnresolvedBlobs(
 
   try {
     debugLog(
-      `Eager download: Found ${syncedTables.length} syncable tables: ${syncedTables.map((t) => t.name).join(', ')}`
+      `Eager download: Found ${syncedTables.length} eligible tables: ${syncedTables
+        .map((t) => t.name)
+        .join(', ')}`
     );
 
     for (const table of syncedTables) {
       if (signal?.aborted) break;
 
+      // Guard against an infinite loop when some rows cannot be cleared
+      // (e.g., blob 404s persistently on the server). We track keys we've
+      // already attempted, and expand the query limit by that count so the
+      // chunk window slides past stuck rows and keeps making progress on
+      // healthy ones. We bail only when even the expanded query produces
+      // no fresh rows, or when too many stuck rows have accumulated.
+      //
+      // MAX_SEEN caps how many stuck rows we tolerate before giving up on
+      // this table. Each stuck row costs one extra download attempt per
+      // iteration, so we keep the cap modest.
+      const MAX_SEEN = 256;
+      const seenKeys = new Set<string>();
+      const primKey = table.schema.primKey;
+      const keyOf = (obj: any): string => {
+        const k = primKey.keyPath
+          ? Dexie.getByKeyPath(obj, primKey.keyPath as string)
+          : undefined;
+        // Stringify so that compound keys (arrays) hash to a stable form.
+        return k === undefined ? '' : JSON.stringify(k);
+      };
+
       try {
-        // Check if table has _hasBlobRefs index
-        const hasIndex = table.schema.indexes.some(
-          (idx) => idx.name === '_hasBlobRefs'
-        );
-        if (!hasIndex) continue;
+        // Loop chunks until the table has no more unresolved rows.
+        // Each toArray() call triggers the blob-resolve middleware, which
+        // downloads (throttled by the tracker) and enqueues saves. We
+        // drain the save queue between chunks so the next query no longer
+        // returns the rows we just processed.
+        while (!signal?.aborted) {
+          // Expand the query window past any stuck rows from earlier
+          // iterations so we still discover fresh rows beyond them.
+          const limit = CHUNK_SIZE + seenKeys.size;
+          const chunk = await table
+            .where('_hasBlobRefs')
+            .equals(1)
+            .limit(limit)
+            .toArray();
 
-        // Query objects with _hasBlobRefs marker
-        const unresolvedObjects = await table
-          .where('_hasBlobRefs')
-          .equals(1)
-          .toArray();
+          if (chunk.length === 0) break;
 
-        debugLog(
-          `Eager download: Table ${table.name} has ${unresolvedObjects.length} unresolved objects`
-        );
-
-        const databaseUrl = db.cloud.options?.databaseUrl;
-        if (!databaseUrl)
-          throw new Error('Database URL is required to download blobs');
-
-        // Download up to MAX_CONCURRENT blobs in parallel
-        const MAX_CONCURRENT = 6;
-        const primaryKey = table.schema.primKey;
-
-        // Filter to actionable objects first
-        const pending = unresolvedObjects.filter((obj) => {
-          if (!hasUnresolvedBlobRefs(obj)) return false;
-          const key = primaryKey.keyPath
-            ? Dexie.getByKeyPath(obj, primaryKey.keyPath as string)
-            : undefined;
-          return key !== undefined;
-        });
-
-        // Process in parallel with concurrency limit
-        let i = 0;
-        const runNext = async (): Promise<void> => {
-          while (i < pending.length) {
-            if (signal?.aborted) return;
-            const obj = pending[i++];
-            const key = Dexie.getByKeyPath(obj, primaryKey.keyPath as string);
-
-            try {
-              // Refresh token per object — cheap (returns cached) but ensures
-              // we pick up renewed tokens during long download sessions.
-              const resolvedBlobs: ResolvedBlob[] = [];
-              try {
-                await resolveAllBlobRefs(
-                  obj,
-                  databaseUrl,
-                  resolvedBlobs,
-                  '',
-                  new WeakMap(),
-                  db.blobDownloadTracker
-                );
-
-                const updateSpec: UpdateSpec<any> = {
-                  _hasBlobRefs: undefined,
-                };
-                for (const blob of resolvedBlobs) {
-                  updateSpec[blob.keyPath] = blob.data;
-                }
-
-                debugLog(
-                  `Eager download: Updating ${table.name}:${key} with ${resolvedBlobs.length} blobs`
-                );
-                await table.update(key, updateSpec);
-                // liveQuery in blobProgress.ts auto-detects this change
-              } finally {
-                // Release the in-flight download cache entries owned by
-                // BlobDownloadTracker. We persist directly via table.update()
-                // here rather than going through the tracker's saving queue,
-                // so we must explicitly release the refs ourselves —
-                // otherwise they would leak in the tracker's inFlight map.
-                if (resolvedBlobs.length > 0) {
-                  db.blobDownloadTracker.releaseRefs(
-                    resolvedBlobs.map((b) => b.ref)
-                  );
-                }
-              }
-            } catch (err) {
-              console.error(
-                `Failed to download blobs for ${table.name}:${key}:`,
-                err
-              );
-            }
+          // Identify rows we have NOT attempted before. If there are none,
+          // the entire remaining table is stuck — give up on this table.
+          let freshCount = 0;
+          for (const obj of chunk) {
+            if (!seenKeys.has(keyOf(obj))) freshCount++;
           }
-        };
+          if (freshCount === 0) {
+            console.warn(
+              `Eager download: ${table.name} stopped — ${chunk.length} rows could not be cleared (likely persistent blob fetch errors)`
+            );
+            break;
+          }
 
-        // Launch up to MAX_CONCURRENT workers
-        const workers: Promise<void>[] = [];
-        for (let w = 0; w < Math.min(MAX_CONCURRENT, pending.length); w++) {
-          workers.push(runNext());
+          for (const obj of chunk) seenKeys.add(keyOf(obj));
+
+          if (seenKeys.size >= MAX_SEEN) {
+            console.warn(
+              `Eager download: ${table.name} stopped — accumulated ${seenKeys.size} stuck rows (cap ${MAX_SEEN})`
+            );
+            break;
+          }
+
+          debugLog(
+            `Eager download: ${table.name} processed chunk of ${chunk.length} (${freshCount} fresh, ${seenKeys.size} total seen)`
+          );
+
+          // Wait for the middleware-driven saves to land in IndexedDB
+          // before re-querying the index.
+          await db.blobDownloadTracker.drainPendingSaves();
         }
-        await Promise.all(workers);
       } catch (err) {
-        // Table might not have _hasBlobRefs index or other issues - skip silently
+        console.error(
+          `Eager download: error processing table ${table.name}:`,
+          err
+        );
       }
     }
   } finally {

--- a/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
+++ b/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
@@ -121,27 +121,40 @@ export async function downloadUnresolvedBlobs(
               // Refresh token per object — cheap (returns cached) but ensures
               // we pick up renewed tokens during long download sessions.
               const resolvedBlobs: ResolvedBlob[] = [];
-              await resolveAllBlobRefs(
-                obj,
-                databaseUrl,
-                resolvedBlobs,
-                '',
-                new WeakMap(),
-                db.blobDownloadTracker
-              );
+              try {
+                await resolveAllBlobRefs(
+                  obj,
+                  databaseUrl,
+                  resolvedBlobs,
+                  '',
+                  new WeakMap(),
+                  db.blobDownloadTracker
+                );
 
-              const updateSpec: UpdateSpec<any> = {
-                _hasBlobRefs: undefined,
-              };
-              for (const blob of resolvedBlobs) {
-                updateSpec[blob.keyPath] = blob.data;
+                const updateSpec: UpdateSpec<any> = {
+                  _hasBlobRefs: undefined,
+                };
+                for (const blob of resolvedBlobs) {
+                  updateSpec[blob.keyPath] = blob.data;
+                }
+
+                debugLog(
+                  `Eager download: Updating ${table.name}:${key} with ${resolvedBlobs.length} blobs`
+                );
+                await table.update(key, updateSpec);
+                // liveQuery in blobProgress.ts auto-detects this change
+              } finally {
+                // Release the in-flight download cache entries owned by
+                // BlobDownloadTracker. We persist directly via table.update()
+                // here rather than going through the tracker's saving queue,
+                // so we must explicitly release the refs ourselves —
+                // otherwise they would leak in the tracker's inFlight map.
+                if (resolvedBlobs.length > 0) {
+                  db.blobDownloadTracker.releaseRefs(
+                    resolvedBlobs.map((b) => b.ref)
+                  );
+                }
               }
-
-              debugLog(
-                `Eager download: Updating ${table.name}:${key} with ${resolvedBlobs.length} blobs`
-              );
-              await table.update(key, updateSpec);
-              // liveQuery in blobProgress.ts auto-detects this change
             } catch (err) {
               console.error(
                 `Failed to download blobs for ${table.name}:${key}:`,

--- a/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
+++ b/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
@@ -4,12 +4,14 @@
  * Downloads unresolved blobs in the background when blobMode='eager'.
  * Called after sync completes to prefetch blobs for offline access.
  *
- * Strategy: simply read rows with `_hasBlobRefs=1` in chunks via the
- * normal middleware stack. The blob-resolve middleware does all the
- * actual work — downloading blobs (throttled and deduplicated by the
- * shared BlobDownloadTracker) and enqueueing them for persistence via
- * the internal save queue. Between chunks we drain the save queue so
- * the next chunk's query no longer sees the just-persisted rows.
+ * Strategy:
+ *   1. Snapshot the primary keys of all rows currently flagged
+ *      `_hasBlobRefs=1` for each syncable table.
+ *   2. Walk that key list in chunks via `bulkGet`. Each `bulkGet`
+ *      triggers the blob-resolve middleware, which does all the actual
+ *      work — downloading blobs (throttled and deduplicated by the
+ *      shared BlobDownloadTracker) and enqueueing them for persistence
+ *      via the internal save queue.
  *
  * This keeps a single, symmetric code path with normal application
  * reads, which is important when other middlewares are present
@@ -17,12 +19,33 @@
  * queue and reads from this loop both pass through the full middleware
  * stack, so on-disk representation stays consistent.
  *
+ * Why a snapshot of primary keys (rather than re-querying the index)?
+ *   - Rows that get resolved by parallel application reads simply
+ *     disappear from the table contents we're about to re-fetch; the
+ *     middleware skips them since `_hasBlobRefs` is already cleared.
+ *   - Stuck rows (e.g., blob 404s) are naturally bypassed: we just
+ *     advance to the next chunk in the snapshot. No `seenKeys`
+ *     bookkeeping required.
+ *   - The snapshot is `string[]`-shaped for typical Dexie Cloud rows
+ *     (~36 bytes/UUID), so ~28K keys per MB. Acceptable for any
+ *     realistic dataset.
+ *
  * Progress is tracked automatically via liveQuery in blobProgress.ts —
  * no manual progress reporting needed here.
+ *
+ * --- Throughput note ---
+ * The chunk loop is sequential: bulkGet → wait for all downloads to
+ * settle → next bulkGet. The save queue drains in the background and
+ * does not block iteration (saves no longer need to be persisted before
+ * the next iteration, since we don't re-query the index). For typical
+ * blob sizes (10 KB – 10 MB) the network dominates total time. If
+ * real-world profiling later shows the per-chunk fixed cost matters,
+ * the next bulkGet could be kicked off in parallel with the current
+ * one's middleware work — but we keep it simple until measurements
+ * justify otherwise.
  */
 
 import { BehaviorSubject } from 'rxjs';
-import Dexie from 'dexie';
 import { setDownloadingState } from './blobProgress';
 import { DexieCloudDB } from '../db/DexieCloudDB';
 import { getSyncableTables } from '../helpers/getSyncableTables';
@@ -31,8 +54,8 @@ import { MAX_CONCURRENT } from './BlobDownloadTracker';
 // One chunk = one full saturation of the tracker's concurrency semaphore.
 // Larger chunks would only buffer more downloaded Uint8Arrays in memory
 // while waiting for the save queue to persist them, without any throughput
-// benefit (the semaphore is the gate, not the query).
-const CHUNK_SIZE = MAX_CONCURRENT;
+// benefit (the semaphore is the gate, not the bulkGet).
+const CHUNK_SIZE = MAX_CONCURRENT - 1; // Leave one slot for parallel app reads that might also trigger downloads
 
 /**
  * Download all unresolved blobs in the background.
@@ -52,21 +75,26 @@ export async function downloadUnresolvedBlobs(
     t.schema.indexes.some((idx) => idx.name === '_hasBlobRefs')
   );
 
-  // Quick check: any work at all?
-  let hasWork = false;
+  // Snapshot the primary keys of all unresolved rows up-front, per table.
+  // Empty arrays are kept so logging is consistent; the loop below skips
+  // tables with no work to do.
+  const workByTable = new Map<string, any[]>();
+  let totalWork = 0;
   for (const table of syncedTables) {
     try {
-      const count = await table.where('_hasBlobRefs').equals(1).count();
-      if (count > 0) {
-        hasWork = true;
-        break;
-      }
-    } catch {
-      // skip
+      const keys = await table.where('_hasBlobRefs').equals(1).primaryKeys();
+      workByTable.set(table.name, keys);
+      totalWork += keys.length;
+    } catch (err) {
+      console.error(
+        `Eager download: failed to list unresolved rows for ${table.name}:`,
+        err
+      );
+      workByTable.set(table.name, []);
     }
   }
 
-  if (!hasWork) {
+  if (totalWork === 0) {
     debugLog('Eager download: No blobs remaining, exiting');
     return;
   }
@@ -75,82 +103,30 @@ export async function downloadUnresolvedBlobs(
 
   try {
     debugLog(
-      `Eager download: Found ${syncedTables.length} eligible tables: ${syncedTables
-        .map((t) => t.name)
-        .join(', ')}`
+      `Eager download: ${totalWork} unresolved row(s) across ${syncedTables.length} table(s)`
     );
 
     for (const table of syncedTables) {
       if (signal?.aborted) break;
-
-      // Guard against an infinite loop when some rows cannot be cleared
-      // (e.g., blob 404s persistently on the server). We track keys we've
-      // already attempted, and expand the query limit by that count so the
-      // chunk window slides past stuck rows and keeps making progress on
-      // healthy ones. We bail only when even the expanded query produces
-      // no fresh rows, or when too many stuck rows have accumulated.
-      //
-      // MAX_SEEN caps how many stuck rows we tolerate before giving up on
-      // this table. Each stuck row costs one extra download attempt per
-      // iteration, so we keep the cap modest.
-      const MAX_SEEN = 256;
-      const seenKeys = new Set<string>();
-      const primKey = table.schema.primKey;
-      const keyOf = (obj: any): string => {
-        const k = primKey.keyPath
-          ? Dexie.getByKeyPath(obj, primKey.keyPath as string)
-          : undefined;
-        // Stringify so that compound keys (arrays) hash to a stable form.
-        return k === undefined ? '' : JSON.stringify(k);
-      };
+      const keys = workByTable.get(table.name);
+      if (!keys || keys.length === 0) continue;
 
       try {
-        // Loop chunks until the table has no more unresolved rows.
-        // Each toArray() call triggers the blob-resolve middleware, which
-        // downloads (throttled by the tracker) and enqueues saves. We
-        // drain the save queue between chunks so the next query no longer
-        // returns the rows we just processed.
-        while (!signal?.aborted) {
-          // Expand the query window past any stuck rows from earlier
-          // iterations so we still discover fresh rows beyond them.
-          const limit = CHUNK_SIZE + seenKeys.size;
-          const chunk = await table
-            .where('_hasBlobRefs')
-            .equals(1)
-            .limit(limit)
-            .toArray();
-
-          if (chunk.length === 0) break;
-
-          // Identify rows we have NOT attempted before. If there are none,
-          // the entire remaining table is stuck — give up on this table.
-          let freshCount = 0;
-          for (const obj of chunk) {
-            if (!seenKeys.has(keyOf(obj))) freshCount++;
-          }
-          if (freshCount === 0) {
-            console.warn(
-              `Eager download: ${table.name} stopped — ${chunk.length} rows could not be cleared (likely persistent blob fetch errors)`
-            );
-            break;
-          }
-
-          for (const obj of chunk) seenKeys.add(keyOf(obj));
-
-          if (seenKeys.size >= MAX_SEEN) {
-            console.warn(
-              `Eager download: ${table.name} stopped — accumulated ${seenKeys.size} stuck rows (cap ${MAX_SEEN})`
-            );
-            break;
-          }
-
+        for (let i = 0; i < keys.length; i += CHUNK_SIZE) {
+          if (signal?.aborted) break;
+          const slice = keys.slice(i, i + CHUNK_SIZE);
+          // bulkGet triggers the blob-resolve middleware for each row that
+          // still has `_hasBlobRefs=1`. Rows already resolved by parallel
+          // reads come back without the marker and the middleware no-ops.
+          // Rows that have been deleted return `undefined` and are
+          // likewise skipped.
+          await table.bulkGet(slice);
           debugLog(
-            `Eager download: ${table.name} processed chunk of ${chunk.length} (${freshCount} fresh, ${seenKeys.size} total seen)`
+            `Eager download: ${table.name} ${Math.min(
+              i + CHUNK_SIZE,
+              keys.length
+            )}/${keys.length}`
           );
-
-          // Wait for the middleware-driven saves to land in IndexedDB
-          // before re-querying the index.
-          await db.blobDownloadTracker.drainPendingSaves();
         }
       } catch (err) {
         console.error(
@@ -159,6 +135,11 @@ export async function downloadUnresolvedBlobs(
         );
       }
     }
+
+    // Make sure all middleware-enqueued saves have landed before we flip
+    // `downloading$` to false — otherwise observers might see a "done"
+    // signal while writes are still in flight.
+    await db.blobDownloadTracker.drainPendingSaves();
   } finally {
     setDownloadingState(downloading$, false);
   }

--- a/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
+++ b/addons/dexie-cloud/src/sync/eagerBlobDownloader.ts
@@ -75,72 +75,66 @@ export async function downloadUnresolvedBlobs(
     t.schema.indexes.some((idx) => idx.name === '_hasBlobRefs')
   );
 
-  // Snapshot the primary keys of all unresolved rows up-front, per table.
-  // Empty arrays are kept so logging is consistent; the loop below skips
-  // tables with no work to do.
-  const workByTable = new Map<string, any[]>();
-  let totalWork = 0;
-  for (const table of syncedTables) {
-    try {
-      const keys = await table.where('_hasBlobRefs').equals(1).primaryKeys();
-      workByTable.set(table.name, keys);
-      totalWork += keys.length;
-    } catch (err) {
-      console.error(
-        `Eager download: failed to list unresolved rows for ${table.name}:`,
-        err
-      );
-      workByTable.set(table.name, []);
-    }
-  }
-
-  if (totalWork === 0) {
-    debugLog('Eager download: No blobs remaining, exiting');
-    return;
-  }
-
-  setDownloadingState(downloading$, true);
+  let started = false;
+  let totalProcessed = 0;
 
   try {
-    debugLog(
-      `Eager download: ${totalWork} unresolved row(s) across ${syncedTables.length} table(s)`
-    );
-
     for (const table of syncedTables) {
       if (signal?.aborted) break;
-      const keys = workByTable.get(table.name);
-      if (!keys || keys.length === 0) continue;
 
+      let keys: any[];
       try {
-        for (let i = 0; i < keys.length; i += CHUNK_SIZE) {
-          if (signal?.aborted) break;
-          const slice = keys.slice(i, i + CHUNK_SIZE);
+        keys = await table.where('_hasBlobRefs').equals(1).primaryKeys();
+      } catch (err) {
+        console.error(
+          `Eager download: failed to list unresolved rows for ${table.name}:`,
+          err
+        );
+        continue;
+      }
+      if (keys.length === 0) continue;
+
+      if (!started) {
+        setDownloadingState(downloading$, true);
+        started = true;
+      }
+
+      debugLog(`Eager download: ${table.name} has ${keys.length} row(s)`);
+
+      for (let i = 0; i < keys.length; i += CHUNK_SIZE) {
+        if (signal?.aborted) break;
+        const slice = keys.slice(i, i + CHUNK_SIZE);
+        try {
           // bulkGet triggers the blob-resolve middleware for each row that
           // still has `_hasBlobRefs=1`. Rows already resolved by parallel
           // reads come back without the marker and the middleware no-ops.
           // Rows that have been deleted return `undefined` and are
           // likewise skipped.
           await table.bulkGet(slice);
-          debugLog(
-            `Eager download: ${table.name} ${Math.min(
-              i + CHUNK_SIZE,
-              keys.length
-            )}/${keys.length}`
-          );
+        } catch (err) {
+          console.error(`Eager download: ${table.name} chunk failed:`, err);
+          continue;
         }
-      } catch (err) {
-        console.error(
-          `Eager download: error processing table ${table.name}:`,
-          err
+        totalProcessed += slice.length;
+        debugLog(
+          `Eager download: ${table.name} ${Math.min(
+            i + CHUNK_SIZE,
+            keys.length
+          )}/${keys.length}`
         );
       }
     }
 
-    // Make sure all middleware-enqueued saves have landed before we flip
-    // `downloading$` to false — otherwise observers might see a "done"
-    // signal while writes are still in flight.
-    await db.blobDownloadTracker.drainPendingSaves();
+    if (started) {
+      // Make sure all middleware-enqueued saves have landed before we flip
+      // `downloading$` to false — otherwise observers might see a "done"
+      // signal while writes are still in flight.
+      await db.blobDownloadTracker.drainPendingSaves();
+      debugLog(`Eager download: done (${totalProcessed} row(s) processed)`);
+    } else {
+      debugLog('Eager download: No blobs remaining, exiting');
+    }
   } finally {
-    setDownloadingState(downloading$, false);
+    if (started) setDownloadingState(downloading$, false);
   }
 }

--- a/addons/dexie-cloud/src/types/TXExpandos.ts
+++ b/addons/dexie-cloud/src/types/TXExpandos.ts
@@ -1,4 +1,4 @@
-import { DBCoreMutateRequest } from 'dexie';
+import { DBCoreMutateRequest, ObservabilitySet } from 'dexie';
 import { DexieCloudSchema } from 'dexie-cloud-common';
 import { UserLogin } from '../db/entities/UserLogin';
 
@@ -10,5 +10,6 @@ export interface TXExpandos {
   disableAccessControl?: boolean;
   disableBlobResolve?: boolean;
   mutationsAdded?: boolean;
+  mutatedParts?: ObservabilitySet;
   opCount: number;
 }

--- a/src/live-query/live-query.ts
+++ b/src/live-query/live-query.ts
@@ -131,7 +131,7 @@ export function liveQuery<T>(querier: () => T | Promise<T>): IObservable<T> {
       // currentObs — it will return false, just accumulating mutations until the
       // query completes and populates currentObs.
       if (!startedListening) {
-        globalEvents(DEXIE_STORAGE_MUTATED_EVENT_NAME, mutationListener);
+        globalEvents.storagemutated.subscribe(mutationListener);
         startedListening = true;
       }
 


### PR DESCRIPTION
## Problem

When using Dexie hooks (e.g. `Table.hook('creating')`) together with lazy blob mode, reads would crash with:

```
[dexie-cloud:blobResolve] Failed to resolve BlobRefs on <table>
```

Caused by:
```
Cannot read properties of undefined (reading 'table')
```

**Root cause:** After an async native `fetch` (blob download), Dexie's PSD zone is no longer active — `PSD.trans` becomes `undefined`. The previous code called `table.mutate()` directly for rw transactions, which flowed through `HooksMiddleware.mutate()`. That reads `PSD.trans` to get the current transaction and crashes.

## Fix

Remove the direct `table.mutate()` path entirely. All blob writebacks now go through `BlobSavingQueue.saveBlobs()`, which:

1. Uses `setTimeout(fn, 0)` to run in a fresh JS task, completely outside any PSD context
2. Opens a proper Dexie `rw` transaction — always safe regardless of calling context

The `BlobSavingQueue` path already existed for readonly transactions and was already correctly armored with `disableChangeTracking`, `disableAccessControl`, and `disableBlobResolve` flags.

## Verified

- Build passes (`pnpm build` clean)
- Unit tests pass (114/114)
- Repro script confirms the underlying PSD bug is real; fix avoids the broken path entirely

Fixes lazy blob mode crash reported by @sarink in Discord.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified blob download/persistence: downloads are deduplicated, concurrency-bounded, and persisted via a central tracker/queue for more reliable saves.
  * Downloader processes work in controlled chunks and defers completion until persistence or explicit release.
* **Bug Fixes**
  * Prevents in-flight reference/cache leaks and ensures pending blob saves can be awaited/drained before signaling completion.
* **New Features**
  * Public API: transaction metadata may include an optional observability field for mutated parts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dexie/Dexie.js/pull/2302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->