### PR TITLE
Fix logins claims update error

### DIFF
--- a/addons/dexie-cloud/package.json
+++ b/addons/dexie-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexie-cloud-addon",
-  "version": "4.4.12",
+  "version": "4.4.13",
   "description": "Dexie addon that syncs with to Dexie Cloud",
   "type": "module",
   "module": "dist/modern/dexie-cloud-addon.js",

--- a/addons/dexie-cloud/src/sync/applyServerChanges.ts
+++ b/addons/dexie-cloud/src/sync/applyServerChanges.ts
@@ -92,17 +92,18 @@ export async function applyServerChanges(
           }
           break;
         case 'update':
-          if (!primaryKey.outbound && primaryKey.keyPath) {
+          if (
+            !primaryKey.outbound &&
+            primaryKey.keyPath &&
+            typeof primaryKey.keyPath === 'string'
+          ) {
             // The primary key should never be part of an updateSpec — it cannot change
             // and is already communicated via the operation's keys array.
             // For private singleton IDs (e.g. "#key:userId" on server, "#key" on client),
             // the encoded server-side key may leak into the changeSpec via getObjectDiff().
             // Strip it here unconditionally as a defensive measure.
             for (const changeSpec of mut.changeSpecs) {
-              Dexie.delByKeyPath(
-                changeSpec as object,
-                primaryKey.keyPath as string
-              );
+              delete changeSpec[primaryKey.keyPath];
             }
           }
           await bulkUpdate(table, keys, mut.changeSpecs);


### PR DESCRIPTION
DataError after updating a user in dexie cloud when that user got an update for the $logins table - it tried to clear out "claims.sub" from the changeSpec. Because delByKeyPath has a bug in earlier…] versions of dexie (now solved), this could lead to that the changeSpec got {claims: {}} in it which led to that the actual inline primary key was changed to undefined - causing:

 DataError Failed to execute 'put' on 'IDBObjectStore': Evaluating the object store's key path did not yield a value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 4.4.13

* **Bug Fixes**
  * Enhanced primary key handling when applying server-side changes to the database

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dexie/Dexie.js/pull/2304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->