### PR TITLE
fix(WhereClause): equalsIgnoreCase silently drops rows on length-changing case fold (ß, ligatures, İ)

### DIFF
--- a/src/classes/where-clause/where-clause-helpers.ts
+++ b/src/classes/where-clause/where-clause-helpers.ts
@@ -81,6 +81,14 @@ export function addIgnoreCaseAlgorithm(
   if (!needles.every((s) => typeof s === 'string')) {
     return fail(whereClause, STRING_EXPECTED);
   }
+  // toUpperCase()/toLowerCase() are not always length- or position-preserving
+  // (e.g. German 'ß' -> 'SS', ligature 'ﬁ' -> 'FI', Turkish 'İ'). The nextCasing()
+  // index-skip optimization below assumes they are; when they aren't, it can skip
+  // past valid records and silently drop matching rows. Detect that case and fall
+  // back to a correct linear scan over the range.
+  const caseFoldUnstable = needles.some(
+    (n) => n.toLowerCase().length !== n.length || n.toUpperCase().length !== n.length
+  );
   function initDirection(dir) {
     upper = upperFactory(dir);
     lower = lowerFactory(dir);
@@ -124,6 +132,14 @@ export function addIgnoreCaseAlgorithm(
     if (match(lowerKey, lowerNeedles, firstPossibleNeedle)) {
       return true;
     } else {
+      if (caseFoldUnstable) {
+        // Length-changing case fold detected: the casing-skip below is unsafe and
+        // would drop rows. Advance one record at a time (correct linear scan).
+        advance(function () {
+          cursor.continue();
+        });
+        return false;
+      }
       var lowestPossibleCasing = null;
       for (var i = firstPossibleNeedle; i < needlesLen; ++i) {
         var casing = nextCasing(

--- a/test/tests-whereclause.js
+++ b/test/tests-whereclause.js
@@ -366,10 +366,10 @@ asyncTest("equalsIgnoreCase() 3 (first key shorter than needle)", function () {
     }).finally(start);
 });
 
-asyncTest("equalsIgnoreCase() with length-changing case fold (ß / ligatures / İ)", function () {
-    // toUpperCase()/toLowerCase() are not always length-preserving: German 'ß' -> 'SS',
-    // ligature 'ﬁ' -> 'FI', Turkish 'İ'. The case-insensitive index walk must not skip
-    // and silently drop such rows. All variants below fold to 'straße'.
+asyncTest("equalsIgnoreCase() with length-changing case fold (ß)", function () {
+    // toUpperCase()/toLowerCase() are not always length-preserving. German 'ß' -> 'SS'
+    // is enough to make the case-insensitive index walk skip and silently drop rows.
+    // All variants below fold to 'straße'.
     var folder = new Folder();
     folder.path = "/casefold";
     db.folders.add(folder).then(function (folderId) {

--- a/test/tests-whereclause.js
+++ b/test/tests-whereclause.js
@@ -366,6 +366,32 @@ asyncTest("equalsIgnoreCase() 3 (first key shorter than needle)", function () {
     }).finally(start);
 });
 
+asyncTest("equalsIgnoreCase() with length-changing case fold (ß / ligatures / İ)", function () {
+    // toUpperCase()/toLowerCase() are not always length-preserving: German 'ß' -> 'SS',
+    // ligature 'ﬁ' -> 'FI', Turkish 'İ'. The case-insensitive index walk must not skip
+    // and silently drop such rows. All variants below fold to 'straße'.
+    var folder = new Folder();
+    folder.path = "/casefold";
+    db.folders.add(folder).then(function (folderId) {
+        var filenames = ["straße", "STRAßE", "Straße", "STRASSE", "strasse"];
+        return db.transaction("rw", db.files, function () {
+            filenames.forEach(function (filename) {
+                var file = new File();
+                file.filename = filename;
+                file.folderId = folderId;
+                db.files.add(file);
+            });
+            db.files.where("filename").equalsIgnoreCase("straße").toArray(function (a) {
+                var got = a.map(function (f) { return f.filename; }).sort().join(",");
+                equal(a.length, 3, "Should match all 3 case variants folding to 'straße' (none silently dropped)");
+                equal(got, "STRAßE,Straße,straße", "Returned variants: " + got);
+            });
+        });
+    }).catch(function (e) {
+        ok(false, "Error: " + (e.stack || e));
+    }).finally(start);
+});
+
 asyncTest("startsWithIgnoreCase()", function () {
     db.transaction("r", db.folders, function () {
 


### PR DESCRIPTION
## Problem

`equalsIgnoreCase()` (and `startsWithIgnoreCase()` / `anyOfIgnoreCase()` / `startsWithAnyOfIgnoreCase()`) can **silently return incomplete results** when the data or query contains characters whose case conversion changes string length — German `ß` → `SS`, ligatures like `ﬁ` → `FI`, Turkish `İ`, etc. This can also defeat case-insensitive uniqueness checks (an existing variant is reported as absent).

### Reproduction (dexie@4.4.3)

```js
import 'fake-indexeddb/auto';
import Dexie from 'dexie';
const db = new Dexie('t');
db.version(1).stores({ items: '++id,name' });
await db.items.bulkAdd(['straße','STRAßE','Straße'].map(name => ({ name })));
await db.items.where('name').equalsIgnoreCase('straße').toArray();
// Expected: ['straße','STRAßE','Straße']  (all fold to 'straße')
// Actual:   ['straße','Straße']           <-- 'STRAßE' is silently dropped
```

### Root cause

`addIgnoreCaseAlgorithm` / `nextCasing` walk the index char-by-char, assuming `upper(needle)`, `lower(needle)` and `lower(key)` line up position-for-position with the original string. `'straße'.toUpperCase()` is `'STRASSE'` (6 → 7 chars), so `upperNeedle` misaligns with the key, `nextCasing` computes a too-large skip target, and `cursor.continue(skipTarget)` jumps past valid records.

## Fix

Detect when any needle is not length-stable under case folding and, for that (rare) case, fall back to a linear scan over the existing range — which always returns correct results. The index-skip optimization (the unsafe part) is bypassed only when needed; the common ASCII / length-stable path is completely unchanged.

## Verification

Verified against the shipped 4.4.3 build with `fake-indexeddb`:

```
PASS  equalsIgnoreCase("straße")      got=[STRAßE,Straße,sTRAßE,straße]  (was missing STRAßE)
PASS  startsWithIgnoreCase("stra")    all 6 variants returned
PASS  equalsIgnoreCase("hello")       ASCII fast path intact
PASS  startsWithIgnoreCase("hel")     ASCII fast path intact
```

Added a regression test in `test/tests-whereclause.js` mirroring the existing `equalsIgnoreCase()` tests.

### Note on performance

For length-unstable needles the fallback scans the index range linearly instead of skipping. This only affects queries whose needle contains length-changing characters (uncommon); correctness over silent data loss seems the right trade-off, and a more surgical length-aware `nextCasing` could replace it later. Happy to iterate on the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed case-insensitive matching for Unicode characters with length-changing case folds (e.g., German ß, ligatures, Turkish İ) by avoiding optimizations that could skip valid rows, ensuring all matching records are returned.

* **Tests**
  * Added a test verifying case-insensitive queries return correct results for filenames containing ß with varying casings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->