### PR TITLE
fix(client): skip pushing changes and prevent retries on expired or deactivated licenses

### DIFF
--- a/addons/dexie-cloud/src/service-worker.ts
+++ b/addons/dexie-cloud/src/service-worker.ts
@@ -86,8 +86,12 @@ function syncDB(dbName: string, purpose: 'push' | 'pull') {
       // Error occured. Stop managing this DB until we wake up again by a sync event,
       // which will open a new Dexie and start trying to sync it.
       stopManagingDB();
-      if (e.name !== Dexie.errnames.NoSuchDatabase) {
-        // Unless the error was that DB doesn't exist, rethrow to trigger sync retry.
+      if (
+        e.name !== Dexie.errnames.NoSuchDatabase &&
+        e.name !== 'InvalidLicenseError' &&
+        !(e.name === 'HttpError' && e.httpStatus === 403)
+      ) {
+        // Unless the error was that DB doesn't exist or is a license/forbidden error, rethrow to trigger sync retry.
         throw e; // Throw e to make syncEvent.waitUntil() receive a rejected promis, so it will retry.
       }
     }
@@ -120,6 +124,12 @@ if (!DISABLE_SERVICEWORKER_STRATEGY) {
       // But lesser timeout and more number of times.
       const syncAndRetry = (num = 1) => {
         return syncDB(dbName, event.data.purpose || 'pull').catch(async (e) => {
+          if (
+            e.name === 'InvalidLicenseError' ||
+            (e.name === 'HttpError' && e.httpStatus === 403)
+          ) {
+            return; // Stop retrying on license errors!
+          }
           if (num === 3) throw e;
           await sleep(60_000); // 1 minute
           syncAndRetry(num + 1);

--- a/addons/dexie-cloud/src/sync/LocalSyncWorker.ts
+++ b/addons/dexie-cloud/src/sync/LocalSyncWorker.ts
@@ -49,6 +49,16 @@ export function LocalSyncWorker(
             ongoingSync = false;
             nextRetryTime = 0;
             syncStartTime = 0;
+          } else if (
+            error &&
+            ((error as any).name === 'InvalidLicenseError' ||
+              ((error as any).name === 'HttpError' &&
+                (error as any).httpStatus === 403))
+          ) {
+            // Do not retry on license errors or 403 Forbidden!
+            ongoingSync = false;
+            nextRetryTime = 0;
+            syncStartTime = 0;
           } else if (retryNum < 5) {
             // Mimic service worker sync event but a bit more eager: retry 4 times
             // * first retry after 20 seconds

--- a/addons/dexie-cloud/src/sync/syncWithServer.ts
+++ b/addons/dexie-cloud/src/sync/syncWithServer.ts
@@ -5,6 +5,7 @@ import { TSON } from '../TSON';
 import { getSyncableTables } from '../helpers/getSyncableTables';
 import { BaseRevisionMapEntry } from '../db/entities/BaseRevisionMapEntry';
 import { HttpError } from '../errors/HttpError';
+import { InvalidLicenseError } from '../InvalidLicenseError';
 import {
   DBOperationsSet,
   DexieCloudSchema,
@@ -36,16 +37,20 @@ export async function syncWithServer(
     'Content-Type': 'application/tson',
   };
   const updatedUser = await loadAccessToken(db);
-  /*
-  if (updatedUser?.license && changes.length > 0) {
+
+  const hasLocalChanges =
+    changes.some((set) => set.muts.some((mut) => mut.keys.length > 0)) ||
+    y.some((m) => m.type === 'u-c');
+
+  if (updatedUser?.license && hasLocalChanges) {
     if (updatedUser.license.status === 'expired') {
-      throw new Error(`License has expired`);
+      throw new InvalidLicenseError('expired');
     }
     if (updatedUser.license.status === 'deactivated') {
-      throw new Error(`License deactivated`);
+      throw new InvalidLicenseError('deactivated');
     }
   }
-  */
+
   const accessToken = updatedUser?.accessToken;
   if (accessToken) {
     headers.Authorization = `Bearer ${accessToken}`;


### PR DESCRIPTION
This PR implements client-side controls to prevent unnecessary large sync payloads and retries when a license is expired or deactivated, while still supporting pull-only syncs and manual/aggressive token refreshes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced license validation and error handling during database synchronization
  * Sync operations now immediately fail for invalid, expired, or deactivated licenses and HTTP 403 Forbidden errors, preventing unnecessary retry attempts
  * Added proactive license status verification before sync operations begin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->