### PR TITLE
feat(dexie-cloud-addon): validate permissions schema on members and roles client-side

### DIFF
--- a/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
@@ -28,6 +28,25 @@ export function createImplicitPropSetterMiddleware(
 
               if (db.cloud.schema?.[tableName]?.markedForSync) {
                 if (req.type === 'add' || req.type === 'put') {
+                  if (tableName === 'members' || tableName === 'roles') {
+                    for (const obj of req.values) {
+                      if (obj && 'permissions' in obj) {
+                        validatePermissions(obj.permissions, tableName);
+                      }
+                    }
+                    if (req.type === 'put') {
+                      const changeSpec = 'changeSpec' in req ? (req as any).changeSpec : undefined;
+                      if (changeSpec) {
+                        validateChangeSpec(changeSpec, tableName);
+                      }
+                      const updates = 'updates' in req ? (req as any).updates : undefined;
+                      if (updates && updates.changeSpecs) {
+                        for (const spec of updates.changeSpecs) {
+                          validateChangeSpec(spec, tableName);
+                        }
+                      }
+                    }
+                  }
                   if (tableName === 'members') {
                     for (const member of req.values) {
                       if (typeof member.email === 'string') {
@@ -89,4 +108,64 @@ export function createImplicitPropSetterMiddleware(
       };
     },
   };
+}
+
+function validatePermissions(permissions: any, tableName: string) {
+  if (permissions === undefined) return;
+  if (permissions === null || typeof permissions !== 'object' || Array.isArray(permissions)) {
+    throw new TypeError(`Invalid permissions format in ${tableName}: permissions must be an object.`);
+  }
+
+  const { add, update, manage } = permissions;
+
+  if (add !== undefined) {
+    if (add !== '*' && (!Array.isArray(add) || add.some(x => typeof x !== 'string'))) {
+      throw new TypeError(`Invalid 'add' permission format in ${tableName}: must be '*' or an array of strings.`);
+    }
+  }
+
+  if (manage !== undefined) {
+    if (manage !== '*' && (!Array.isArray(manage) || manage.some(x => typeof x !== 'string'))) {
+      throw new TypeError(`Invalid 'manage' permission format in ${tableName}: must be '*' or an array of strings.`);
+    }
+  }
+
+  if (update !== undefined) {
+    if (update === null || typeof update !== 'object' || Array.isArray(update)) {
+      throw new TypeError(`Invalid 'update' permission format in ${tableName}: must be an object.`);
+    }
+    for (const [tbl, props] of Object.entries(update)) {
+      if (props !== '*' && (!Array.isArray(props) || props.some(x => typeof x !== 'string'))) {
+        throw new TypeError(`Invalid update permission properties format for table '${tbl}' in ${tableName}: must be '*' or an array of strings.`);
+      }
+    }
+  }
+}
+
+function validateChangeSpec(changeSpec: { [keyPath: string]: any }, tableName: string) {
+  if (!changeSpec) return;
+  for (const [keyPath, value] of Object.entries(changeSpec)) {
+    if (keyPath === 'permissions') {
+      validatePermissions(value, tableName);
+    } else if (keyPath === 'permissions.add' || keyPath === 'permissions.manage') {
+      if (value !== undefined && value !== '*' && (!Array.isArray(value) || value.some(x => typeof x !== 'string'))) {
+        throw new TypeError(`Invalid '${keyPath}' format in ${tableName}: must be '*' or an array of strings.`);
+      }
+    } else if (keyPath === 'permissions.update') {
+      if (value !== undefined) {
+        if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+          throw new TypeError(`Invalid 'permissions.update' format in ${tableName}: must be an object.`);
+        }
+        for (const [tbl, props] of Object.entries(value)) {
+          if (props !== '*' && (!Array.isArray(props) || props.some(x => typeof x !== 'string'))) {
+            throw new TypeError(`Invalid update permission properties format for table '${tbl}' in ${tableName}: must be '*' or an array of strings.`);
+          }
+        }
+      }
+    } else if (keyPath.startsWith('permissions.update.')) {
+      if (value !== undefined && value !== '*' && (!Array.isArray(value) || value.some(x => typeof x !== 'string'))) {
+        throw new TypeError(`Invalid update properties format for '${keyPath}' in ${tableName}: must be '*' or an array of strings.`);
+      }
+    }
+  }
 }

--- a/addons/dexie-cloud/test/unit/index.ts
+++ b/addons/dexie-cloud/test/unit/index.ts
@@ -1,2 +1,3 @@
 import "./tests-github-issues";
 import "./tests-migrate-to-cloud";
+import "./tests-validation";

--- a/addons/dexie-cloud/test/unit/karma.conf.cjs
+++ b/addons/dexie-cloud/test/unit/karma.conf.cjs
@@ -34,5 +34,13 @@ module.exports = function (config) {
   cfg.hostname = 'localhost';
   cfg.port = 9876;
 
+  cfg.customLaunchers = {
+    ChromeHeadlessNoSandbox: {
+      base: 'ChromeHeadless',
+      flags: ['--no-sandbox', '--disable-setuid-sandbox']
+    }
+  };
+  cfg.browsers = ['ChromeHeadlessNoSandbox'];
+
   config.set(cfg);
 }

--- a/addons/dexie-cloud/test/unit/tests-validation.ts
+++ b/addons/dexie-cloud/test/unit/tests-validation.ts
@@ -1,0 +1,92 @@
+import {
+  module,
+  ok,
+} from 'qunit';
+import { promisedTest } from '../promisedTest';
+import Dexie from 'dexie';
+import dexieCloud from '../../src/dexie-cloud-client';
+
+module('validation');
+
+const DATABASE_URL = 'http://localhost:3000/ziud0envo';
+
+promisedTest('validate-permissions-format', async () => {
+  const testDb = new Dexie('permissionsTestDb', { addons: [dexieCloud] });
+  await Dexie.delete(testDb.name);
+  testDb.version(1).stores({
+    members: "@id, realmId",
+    roles: "[realmId+name]"
+  });
+  testDb.cloud.configure({
+    databaseUrl: DATABASE_URL,
+    requireAuth: false
+  });
+  await testDb.open();
+
+  try {
+    // 1. Valid permissions should succeed
+    try {
+      await testDb.table('members').add({
+        id: 'm1',
+        realmId: 'r1',
+        email: 'valid@example.com',
+        permissions: {
+          add: ['todoLists'],
+          manage: '*',
+          update: {
+            todoLists: ['title']
+          }
+        }
+      });
+      ok(true, "Valid permissions accepted");
+    } catch (err) {
+      ok(false, "Valid permissions should have been accepted: " + err);
+    }
+
+    // 2. Invalid permissions (manage: true) should throw TypeError
+    try {
+      await testDb.table('members').add({
+        id: 'm2',
+        realmId: 'r1',
+        email: 'invalid@example.com',
+        permissions: {
+          manage: true as any
+        }
+      });
+      ok(false, "Invalid manage: true should have been rejected");
+    } catch (err: any) {
+      ok(err instanceof TypeError, "Rejected invalid permissions with TypeError: " + err.message);
+    }
+
+    // 3. Invalid update permissions (string instead of array) should throw TypeError
+    try {
+      await testDb.table('members').add({
+        id: 'm3',
+        realmId: 'r1',
+        email: 'invalid2@example.com',
+        permissions: {
+          update: {
+            todoLists: 'not-an-array' as any
+          }
+        }
+      });
+      ok(false, "Invalid update property format should have been rejected");
+    } catch (err: any) {
+      ok(err instanceof TypeError, "Rejected invalid update properties with TypeError: " + err.message);
+    }
+
+    // 4. Invalid roles permissions (non-object permissions) should throw TypeError
+    try {
+      await testDb.table('roles').add({
+        realmId: 'r1',
+        name: 'r1',
+        permissions: 'not-an-object' as any
+      });
+      ok(false, "Invalid non-object permissions on role should have been rejected");
+    } catch (err: any) {
+      ok(err instanceof TypeError, "Rejected invalid role permissions with TypeError: " + err.message);
+    }
+  } finally {
+    testDb.close();
+  }
+});


### PR DESCRIPTION
Check permissions format directly in dexie-cloud-addon during client-side mutations (add, put, update) on 'members' and 'roles' tables. This will throw a clear TypeError on the client side immediately rather than sinking or syncing invalid permissions format to the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation logic for permission configurations when syncing members and roles data, ensuring proper format compliance and preventing invalid permission structures from being synced.

* **Tests**
  * Added comprehensive unit test coverage for permission validation with multiple scenarios including valid and invalid permission formats.
  * Updated test runner configuration to support headless browser testing with improved environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->