### PR TITLE
fix(client): clone frozen/sealed/non-extensible objects in applyServerChanges

### DIFF
--- a/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
@@ -31,6 +31,20 @@ export function createImplicitPropSetterMiddleware(
 
               if (db.cloud.schema?.[tableName]?.markedForSync) {
                 if (req.type === 'add' || req.type === 'put') {
+                  const values = req.values as any[];
+                  for (let i = 0; i < values.length; i++) {
+                    const obj = values[i];
+                    if (
+                      obj &&
+                      typeof obj === 'object' &&
+                      (Object.isFrozen(obj) ||
+                        Object.isSealed(obj) ||
+                        !Object.isExtensible(obj))
+                    ) {
+                      values[i] = { ...obj };
+                    }
+                  }
+
                   if (tableName === 'members') {
                     for (const member of req.values) {
                       if (typeof member.email === 'string') {

--- a/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
@@ -31,69 +31,84 @@ export function createImplicitPropSetterMiddleware(
 
               if (db.cloud.schema?.[tableName]?.markedForSync) {
                 if (req.type === 'add' || req.type === 'put') {
-                  const values = req.values as any[];
-                  for (let i = 0; i < values.length; i++) {
-                    const obj = values[i];
-                    if (
-                      obj &&
-                      typeof obj === 'object' &&
-                      (Object.isFrozen(obj) ||
-                        Object.isSealed(obj) ||
-                        !Object.isExtensible(obj))
-                    ) {
-                      values[i] = { ...obj };
-                    }
-                  }
+                  let values: any[] | null = null;
 
-                  if (tableName === 'members') {
-                    for (const member of req.values) {
-                      if (typeof member.email === 'string') {
-                        // Resolve https://github.com/dexie/dexie-cloud/issues/4
-                        // If adding a member, make sure email is lowercase and trimmed.
-                        // This is to avoid issues where the APP does not check this
-                        // and just allows the user to enter an email address that might
-                        // have been pasted by the user from a source that had a trailing
-                        // space or was in uppercase. We want to avoid that the user
-                        // creates a new member with a different email address than
-                        // the one he/she intended to create.
-                        member.email = member.email.trim().toLowerCase();
+                  for (let i = 0; i < req.values.length; i++) {
+                    const obj = req.values[i];
+                    if (obj && typeof obj === 'object') {
+                      let needsClone = false;
+                      let email = obj.email;
+                      if (tableName === 'members' && typeof email === 'string') {
+                        const trimmedLower = email.trim().toLowerCase();
+                        if (trimmedLower !== email) {
+                          needsClone = true;
+                          email = trimmedLower;
+                        }
+                      }
+
+                      const owner = obj.owner || currentUserId;
+                      const realmId = obj.realmId || currentUserId;
+                      if (owner !== obj.owner || realmId !== obj.realmId) {
+                        needsClone = true;
+                      }
+
+                      let ts = obj.$ts;
+                      let isPrivatePut = false;
+                      if (req.type === 'put') {
+                        const key = table.schema.primaryKey.extractKey?.(obj);
+                        if (typeof key === 'string' && key[0] === '#') {
+                          isPrivatePut = true;
+                          ts = Date.now();
+                          if (ts !== obj.$ts) {
+                            needsClone = true;
+                          }
+                        }
+                      }
+
+                      if (
+                        !needsClone &&
+                        (Object.isFrozen(obj) ||
+                          Object.isSealed(obj) ||
+                          !Object.isExtensible(obj))
+                      ) {
+                        needsClone = true;
+                      }
+
+                      if (needsClone) {
+                        if (!values) {
+                          values = [...req.values];
+                        }
+                        const cloned = { ...obj };
+                        if (tableName === 'members' && typeof email === 'string') {
+                          cloned.email = email;
+                        }
+                        cloned.owner = owner;
+                        cloned.realmId = realmId;
+                        if (isPrivatePut) {
+                          cloned.$ts = ts;
+                        }
+                        values[i] = cloned;
                       }
                     }
                   }
-                  // No matter if user is logged in or not, make sure "owner" and "realmId" props are set properly.
-                  // If not logged in, this will be changed upon syncification of the tables (next sync after login),
-                  // however, application code will work better if we can always rely on that the properties realmId
-                  // and owner are set. Application code may index them and query them based on db.cloud.currentUserId,
-                  // and expect them to be returned. That scenario must work also when db.cloud.currentUserId === 'unauthorized'.
+
+                  if (values) {
+                    req = { ...req, values };
+                  }
+
+                  // Handle degrading the request for private IDs if needed:
+                  let mutatedReq = false;
                   for (const obj of req.values) {
-                    if (!obj.owner) {
-                      obj.owner = currentUserId;
-                    }
-                    if (!obj.realmId) {
-                      obj.realmId = currentUserId;
-                    }
                     const key = table.schema.primaryKey.extractKey?.(obj);
                     if (typeof key === 'string' && key[0] === '#') {
-                      // Add $ts prop for put operations and
-                      // disable update operations as well as consistent
-                      // modify operations. Reason: Server may not have
-                      // the object. Object should be created on server only
-                      // if is being updated. An update operation won't create it
-                      // so we must delete req.changeSpec to degrade operation to
-                      // an upsert operation with timestamp so that it will be created.
-                      // We must also degrade from consistent modify operations for the
-                      // same reason - object might be there on server. Must but put up instead.
-
-                      // FUTURE: This clumpsy behavior of private IDs could be refined later.
-                      // Suggestion is to in future, treat private IDs as we treat all objects
-                      // and sync operations normally. Only that deletions should become soft deletes
-                      // for them - so that server knows when a private ID has been deleted on server
-                      // not accept insert/upserts on them.
                       if (req.type === 'put') {
+                        if (!mutatedReq) {
+                          req = { ...req };
+                          mutatedReq = true;
+                        }
                         delete req.criteria;
                         delete req.changeSpec;
                         if (!req.upsert) delete req.updates;
-                        obj.$ts = Date.now();
                       }
                     }
                   }

--- a/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
+++ b/addons/dexie-cloud/src/middlewares/createImplicitPropSetterMiddleware.ts
@@ -36,21 +36,18 @@ export function createImplicitPropSetterMiddleware(
                   for (let i = 0; i < req.values.length; i++) {
                     const obj = req.values[i];
                     if (obj && typeof obj === 'object') {
-                      let needsClone = false;
                       let email = obj.email;
+                      let hasEmailChange = false;
                       if (tableName === 'members' && typeof email === 'string') {
                         const trimmedLower = email.trim().toLowerCase();
                         if (trimmedLower !== email) {
-                          needsClone = true;
+                          hasEmailChange = true;
                           email = trimmedLower;
                         }
                       }
 
                       const owner = obj.owner || currentUserId;
                       const realmId = obj.realmId || currentUserId;
-                      if (owner !== obj.owner || realmId !== obj.realmId) {
-                        needsClone = true;
-                      }
 
                       let ts = obj.$ts;
                       let isPrivatePut = false;
@@ -59,35 +56,48 @@ export function createImplicitPropSetterMiddleware(
                         if (typeof key === 'string' && key[0] === '#') {
                           isPrivatePut = true;
                           ts = Date.now();
-                          if (ts !== obj.$ts) {
-                            needsClone = true;
-                          }
                         }
                       }
 
-                      if (
-                        !needsClone &&
-                        (Object.isFrozen(obj) ||
-                          Object.isSealed(obj) ||
-                          !Object.isExtensible(obj))
-                      ) {
-                        needsClone = true;
-                      }
+                      const isFrozen =
+                        Object.isFrozen(obj) ||
+                        Object.isSealed(obj) ||
+                        !Object.isExtensible(obj);
 
-                      if (needsClone) {
+                      if (isFrozen) {
+                        // For frozen objects, we MUST clone to prevent error on writing properties,
+                        // and we also build a cloned values array.
                         if (!values) {
                           values = [...req.values];
                         }
-                        const cloned = { ...obj };
+                        const clonedObj = { ...obj };
                         if (tableName === 'members' && typeof email === 'string') {
-                          cloned.email = email;
+                          clonedObj.email = email;
                         }
-                        cloned.owner = owner;
-                        cloned.realmId = realmId;
+                        clonedObj.owner = owner;
+                        clonedObj.realmId = realmId;
                         if (isPrivatePut) {
-                          cloned.$ts = ts;
+                          clonedObj.$ts = ts;
                         }
-                        values[i] = cloned;
+                        values[i] = clonedObj;
+                      } else {
+                        // For normal extensible objects, we mutate in-place to preserve
+                        // backward compatibility (so caller references get owner/realmId/etc.)
+                        if (hasEmailChange) {
+                          obj.email = email;
+                        }
+                        if (!obj.owner) {
+                          obj.owner = owner;
+                        }
+                        if (!obj.realmId) {
+                          obj.realmId = realmId;
+                        }
+                        if (isPrivatePut) {
+                          obj.$ts = ts;
+                        }
+                        if (values) {
+                          values[i] = obj;
+                        }
                       }
                     }
                   }

--- a/addons/dexie-cloud/src/sync/applyServerChanges.ts
+++ b/addons/dexie-cloud/src/sync/applyServerChanges.ts
@@ -61,6 +61,18 @@ export async function applyServerChanges(
       const keys = mut.keys.map(keyDecoder);
       switch (mut.type) {
         case 'insert':
+          mut.values = mut.values.map((val) => {
+            if (
+              val &&
+              typeof val === 'object' &&
+              (Object.isFrozen(val) ||
+                Object.isSealed(val) ||
+                !Object.isExtensible(val))
+            ) {
+              return { ...val };
+            }
+            return val;
+          });
           mut.values.forEach(markIfHasBlobRefs);
           if (primaryKey.outbound) {
             await table.bulkAdd(mut.values, keys);
@@ -73,6 +85,18 @@ export async function applyServerChanges(
           }
           break;
         case 'upsert':
+          mut.values = mut.values.map((val) => {
+            if (
+              val &&
+              typeof val === 'object' &&
+              (Object.isFrozen(val) ||
+                Object.isSealed(val) ||
+                !Object.isExtensible(val))
+            ) {
+              return { ...val };
+            }
+            return val;
+          });
           mut.values.forEach(markIfHasBlobRefs);
           if (primaryKey.outbound) {
             await table.bulkPut(mut.values, keys);
@@ -102,7 +126,18 @@ export async function applyServerChanges(
             // For private singleton IDs (e.g. "#key:userId" on server, "#key" on client),
             // the encoded server-side key may leak into the changeSpec via getObjectDiff().
             // Strip it here unconditionally as a defensive measure.
-            for (const changeSpec of mut.changeSpecs) {
+            for (let i = 0; i < mut.changeSpecs.length; i++) {
+              let changeSpec = mut.changeSpecs[i];
+              if (
+                changeSpec &&
+                typeof changeSpec === 'object' &&
+                (Object.isFrozen(changeSpec) ||
+                  Object.isSealed(changeSpec) ||
+                  !Object.isExtensible(changeSpec))
+              ) {
+                changeSpec = { ...changeSpec };
+                mut.changeSpecs[i] = changeSpec;
+              }
               delete changeSpec[primaryKey.keyPath];
             }
           }

--- a/addons/dexie-cloud/src/sync/listClientChanges.ts
+++ b/addons/dexie-cloud/src/sync/listClientChanges.ts
@@ -1,4 +1,4 @@
-import { PropModification, Table, UpdateSpec } from 'dexie';
+import Dexie, { PropModification, Table, UpdateSpec } from 'dexie';
 import { getTableFromMutationTable } from '../helpers/getTableFromMutationTable';
 import { DexieCloudDB } from '../db/DexieCloudDB';
 import {
@@ -70,7 +70,7 @@ export async function listClientChanges(
   }
 
   // Filter out those tables that doesn't have any mutations:
-  return result;
+  return Dexie.deepClone(result);
 }
 
 function removeRedundantUpdateOps(muts: DBOperation[]) {

--- a/addons/dexie-cloud/test/unit/test-dexie-cloud-client.ts
+++ b/addons/dexie-cloud/test/unit/test-dexie-cloud-client.ts
@@ -191,6 +191,65 @@ promisedTest('add-realm', async () => {
   console.log('After syncing the realm removal');
 });
 
+import { applyServerChanges } from '../../src/sync/applyServerChanges';
+
+promisedTest('applyServerChanges with frozen objects', async () => {
+  const testDb = new Dexie('frozen-test-db', { addons: [dexieCloud] }) as any;
+  testDb.version(1).stores({
+    items: '@id, name',
+  });
+  await Dexie.delete(testDb.name);
+  await testDb.open();
+
+  // Create a frozen object for insertion
+  const frozenVal = Object.freeze({ name: 'Frozen Item' });
+
+  // Define server changes containing the frozen object
+  const changes: any = [
+    {
+      table: 'items',
+      muts: [
+        {
+          type: 'insert',
+          keys: ['item-1'],
+          values: [frozenVal],
+        },
+      ],
+    },
+  ];
+
+  // Apply server changes
+  await applyServerChanges(changes, testDb);
+
+  // Retrieve the item and verify it was inserted successfully
+  const item = await testDb.table('items').get('item-1');
+  ok(item, 'Item was inserted');
+  equal(item.name, 'Frozen Item', 'Item name is correct');
+  equal(item.id, 'item-1', 'Primary key was successfully set on the object');
+
+  // Also verify with upsert & frozen changeSpecs
+  const frozenUpsertVal = Object.freeze({ name: 'Frozen Upsert' });
+  const upsertChanges: any = [
+    {
+      table: 'items',
+      muts: [
+        {
+          type: 'upsert',
+          keys: ['item-2'],
+          values: [frozenUpsertVal],
+        },
+      ],
+    },
+  ];
+  await applyServerChanges(upsertChanges, testDb);
+  const item2 = await testDb.table('items').get('item-2');
+  ok(item2, 'Upsert item was inserted');
+  equal(item2.name, 'Frozen Upsert', 'Upsert item name is correct');
+  equal(item2.id, 'item-2', 'Primary key was successfully set on the upsert object');
+
+  await testDb.close();
+});
+
 /*promisedTest('require-auth', async () => {
   await Dexie.delete(db.name);
   db.cloud.configure({

--- a/addons/dexie-cloud/test/unit/test-dexie-cloud-client.ts
+++ b/addons/dexie-cloud/test/unit/test-dexie-cloud-client.ts
@@ -250,6 +250,33 @@ promisedTest('applyServerChanges with frozen objects', async () => {
   await testDb.close();
 });
 
+promisedTest('implicitPropSetterMiddleware with frozen objects', async () => {
+  const testDb = new Dexie('frozen-propsetter-db', { addons: [dexieCloud] }) as any;
+  testDb.version(1).stores({
+    items: '@id, name',
+  });
+  testDb.cloud.configure({
+    databaseUrl: 'http://localhost:3000/ziud0envo',
+    requireAuth: false,
+  });
+  testDb.cloud.schema = {
+    items: { markedForSync: true },
+  };
+  await Dexie.delete(testDb.name);
+  await testDb.open();
+
+  const frozenVal = Object.freeze({ id: 'f-1', name: 'Frozen Item' });
+  await testDb.table('items').add(frozenVal);
+
+  const item = await testDb.table('items').get('f-1');
+  ok(item, 'Frozen item was written successfully through propSetter');
+  equal(item.name, 'Frozen Item', 'Item name is correct');
+  equal(item.owner, 'unauthorized', 'Implicit owner property was set');
+  equal(item.realmId, 'unauthorized', 'Implicit realmId property was set');
+
+  await testDb.close();
+});
+
 /*promisedTest('require-auth', async () => {
   await Dexie.delete(db.name);
   db.cloud.configure({

--- a/addons/dexie-cloud/test/unit/tests-github-issues.ts
+++ b/addons/dexie-cloud/test/unit/tests-github-issues.ts
@@ -16,6 +16,8 @@ import dexieCloud, {
   DexieCloudTable,
   getTiedRealmId,
 } from '../../src/dexie-cloud-client';
+import { listClientChanges } from '../../src/sync/listClientChanges';
+import { getMutationTable } from '../../src/helpers/getMutationTable';
 
 const DBURL = 'https://zv8n7bwcs.dexie.cloud'; // Shall exist in cloud.
 
@@ -183,3 +185,34 @@ function strip(...props: string[]) {
     return newObj;
   };
 }
+
+promisedTest('https://github.com/dexie/Dexie.js/pull/2317 - frozen objects in listClientChanges', async () => {
+  const testDb = new Dexie('frozen-mutations-db', { addons: [dexieCloud] }) as any;
+  testDb.version(1).stores({
+    items: '@id, name',
+  });
+  testDb.cloud.configure({
+    databaseUrl: DBURL,
+    requireAuth: { email: 'issue2317@demo.local', grant_type: 'demo' },
+  });
+  await Dexie.delete(testDb.name);
+  await testDb.open();
+
+  // Add a frozen object
+  const frozenVal = Object.freeze({ name: 'Frozen Local Item' });
+  await testDb.table('items').add(frozenVal);
+
+  // List client changes
+  const mutationTables = [testDb.table(getMutationTable('items'))];
+  const clientChanges = await listClientChanges(mutationTables, testDb);
+
+  // Verify that the listed mutations and their values are NOT frozen
+  ok(clientChanges.length > 0, 'Client changes were listed');
+  const mut = clientChanges[0].muts[0] as any;
+  ok(!Object.isFrozen(mut), 'Mutation object is not frozen');
+  ok(!Object.isFrozen(mut.values[0]), 'Value inside mutation is not frozen');
+  equal(mut.values[0].name, 'Frozen Local Item', 'Item name is correct');
+
+  await testDb.close();
+  await Dexie.delete(testDb.name);
+});


### PR DESCRIPTION
Fixes a critical client-side bug where server changes fail to apply if the object value is frozen, sealed, or non-extensible (often caused by liveQuery cache or state frameworks/immutability hooks). This leads to a DataError ('Evaluating the object store's key path did not yield a value') which orphans the record on client sides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dexie Cloud sync robustness when incoming values or change specs are frozen, sealed, or non-extensible, preventing runtime mutation failures.
  * Ensured server insert/upsert/update operations correctly apply implicit fields and safely handle immutable payload parts.
  * Client change results are now returned as a detached copy to avoid side effects from later processing.
  * Added safeguards for private-id updates to keep mutation handling consistent.

* **Tests**
  * Added unit coverage for frozen-object sync scenarios, including implicit property behavior and client mutation immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->