### PR TITLE
fix(WhereClause): empty anyOf()/between() no longer empties an or()-union (#1607)

### DIFF
--- a/src/classes/where-clause/where-clause-helpers.ts
+++ b/src/classes/where-clause/where-clause-helpers.ts
@@ -23,7 +23,17 @@ export function fail(
 }
 
 export function emptyCollection(whereClause: WhereClause) {
-  return new whereClause.Collection(whereClause, () => rangeEqual('')).limit(0);
+  // Use a filtering algorithm rather than .limit(0). A .limit() registers a
+  // replayFilter on the resulting collection, and when an empty collection is
+  // the outermost clause of an or()-chain, that replayFilter is applied to the
+  // entire union (see iter() in collection-helpers) and silently empties the
+  // whole result. An algorithm only filters this collection's own cursor and
+  // therefore leaves the other or()-branches untouched. See issue #1607.
+  const collection = new whereClause.Collection(whereClause, () =>
+    rangeEqual('')
+  );
+  collection._addAlgorithm(() => false);
+  return collection;
 }
 
 export function upperFactory(dir: 'next' | 'prev') {

--- a/test/tests-whereclause.js
+++ b/test/tests-whereclause.js
@@ -248,6 +248,36 @@ asyncTest("anyOf(emptyArray)", function () {
     }).finally(start);
 });
 
+asyncTest("Issue#1607 anyOf(emptyArray) combined with or()", function () {
+    // An empty anyOf() as the last clause of an or()-chain must not empty the
+    // whole union - it should just contribute nothing of its own.
+    db.transaction("r", db.files, function () {
+        db.files
+            .where('filename').anyOf(['hello', 'world'])
+            .or('extension').anyOf([])
+            .toArray(function (a) {
+                equal(a.length, 2, "or()-branch results are kept when the other branch is anyOf([])");
+                var names = a.map(function (f) { return f.filename; }).sort();
+                equal(names.join(','), 'hello,world', "Got the two matching files");
+            });
+
+        // count() must reflect the same union, not 0.
+        db.files
+            .where('filename').anyOf(['hello', 'world'])
+            .or('extension').anyOf([])
+            .count(function (n) {
+                equal(n, 2, "count() of the union is unaffected by the empty branch");
+            });
+
+        // A standalone empty anyOf() must still resolve to nothing.
+        db.files.where('extension').anyOf([]).count(function (n) {
+            equal(n, 0, "Standalone anyOf([]) is still empty");
+        });
+    }).catch(function (e) {
+        ok(false, "Error: " + (e.stack || e));
+    }).finally(start);
+});
+
 asyncTest("equalsIgnoreCase()", function () {
 
     db.files.where("filename").equalsIgnoreCase("hello").toArray(function (a) {


### PR DESCRIPTION
Closes #1607.

`emptyCollection()` returned a `Collection` carrying `.limit(0)`. A `.limit()` registers a *replayFilter*, and in `iter()` the outermost collection's replayFilter is applied to the **whole union**. So when an empty clause is the last link of an `or()`-chain, the matches from the other branches were silently dropped:

```js
db.files
  .where('filename').anyOf(['hello', 'world'])
  .or('extension').anyOf([])   // empty -> killed the whole result
  .toArray()                   // [] instead of the two filename matches
```

(Both reporters in #1607 hit this; the trailing empty array comes from dynamically built queries.)

**Fix:** replace `.limit(0)` with a filtering algorithm (`() => false`). An algorithm only filters the empty collection's *own* cursor, so the other `or()`-branches are untouched, while a standalone empty clause still resolves to nothing. This also covers `between(lower > upper)` and the other `emptyCollection` callers.

**Test:** added a regression test in `tests-whereclause.js` (union `toArray`/`count` + standalone-still-empty). Verified failing before / passing after the change.