### PR TITLE
Reject bulkUpdate changes to nested and compound primary keys

### DIFF
--- a/src/classes/table/table.ts
+++ b/src/classes/table/table.ts
@@ -697,22 +697,25 @@ export class Table implements ITable<any, IndexableType> {
     const offsetMap: number[] = [];
     return this._trans('readwrite', (trans) => {
       return coreTable.getMany({ trans, keys, cache: 'clone' }).then((objs) => {
+        const { outbound, extractKey } = coreTable.schema.primaryKey;
         const resultKeys: any[] = [];
         const resultObjs: any[] = [];
         keysAndChanges.forEach(({ key, changes }, idx) => {
           const obj = objs[idx];
           if (obj) {
             for (const keyPath of Object.keys(changes)) {
-              const value = changes[keyPath];
-              if (keyPath === this.schema.primKey.keyPath) {
-                if (cmp(value, key) !== 0) {
-                  throw new exceptions.Constraint(
-                    `Cannot update primary key in bulkUpdate()`
-                  );
-                }
-              } else {
-                setByKeyPath(obj, keyPath, value);
-              }
+              setByKeyPath(obj, keyPath, changes[keyPath]);
+            }
+            // Applying the changes must not move the record to a different
+            // primary key. Comparing the change keyPath against primKey.keyPath
+            // (the previous approach) silently missed compound keys, whose
+            // keyPath is an array, and nested keys changed via a parent object.
+            // Extract the resulting key the same way Collection.modify() does
+            // and reject any change to an inbound primary key.
+            if (!outbound && cmp(extractKey(obj), key) !== 0) {
+              throw new exceptions.Constraint(
+                `Cannot update primary key in bulkUpdate()`
+              );
             }
             offsetMap.push(idx);
             resultKeys.push(key);

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -529,6 +529,44 @@ promisedTest("bulkUpdate without actual changes (check it doesn't bail out)", as
 });
 
 
+promisedTest("bulkUpdate must not change an inbound primary key (compound & nested) [issue #2218]", async ()=>{
+    const db = new Dexie("BulkUpdatePrimKeyTest");
+    db.version(1).stores({
+        compound: "[a+b]",
+        nested: "foo.bar"
+    });
+    try {
+        await db.open();
+
+        // Compound primary key: changing a key component must be rejected, not
+        // silently create a new record at a different key.
+        await db.compound.bulkAdd([{a: 1, b: 2, v: "x"}]);
+        let err = null;
+        try {
+            await db.compound.bulkUpdate([{key: [1, 2], changes: {a: 9}}]);
+        } catch (e) { err = e; }
+        equal(err && err.name, "ConstraintError", "Changing a compound key component in bulkUpdate() should throw ConstraintError");
+        equal(await db.compound.count(), 1, "No duplicate record should have been created for the compound key");
+        deepEqual(await db.compound.toArray(), [{a: 1, b: 2, v: "x"}], "The original compound-key record is left unchanged");
+
+        // Nested primary key: replacing the parent object that holds the key
+        // must be rejected too (this path was previously uncaught).
+        await db.nested.bulkAdd([{foo: {bar: 1}, v: "x"}]);
+        let err2 = null;
+        try {
+            await db.nested.bulkUpdate([{key: 1, changes: {foo: {bar: 9}}}]);
+        } catch (e) { err2 = e; }
+        equal(err2 && err2.name, "ConstraintError", "Replacing a nested-key parent object in bulkUpdate() should throw ConstraintError");
+        equal(await db.nested.count(), 1, "No duplicate record should have been created for the nested key");
+
+        // Updating a non-key field on a compound-key table must still succeed.
+        await db.compound.bulkUpdate([{key: [1, 2], changes: {v: "y"}}]);
+        deepEqual(await db.compound.toArray(), [{a: 1, b: 2, v: "y"}], "A non-key update on a compound-key table still applies");
+    } finally {
+        await db.delete();
+    }
+});
+
 promisedTest("bulkUpdate with failure", async ()=>{
     if (isSafari) {
         // Avoid bug https://bugs.webkit.org/show_bug.cgi?id=247053

--- a/test/tests-table.js
+++ b/test/tests-table.js
@@ -558,6 +558,7 @@ promisedTest("bulkUpdate must not change an inbound primary key (compound & nest
         } catch (e) { err2 = e; }
         equal(err2 && err2.name, "ConstraintError", "Replacing a nested-key parent object in bulkUpdate() should throw ConstraintError");
         equal(await db.nested.count(), 1, "No duplicate record should have been created for the nested key");
+        deepEqual(await db.nested.toArray(), [{foo: {bar: 1}, v: "x"}], "The original nested-key record is left unchanged");
 
         // Updating a non-key field on a compound-key table must still succeed.
         await db.compound.bulkUpdate([{key: [1, 2], changes: {v: "y"}}]);


### PR DESCRIPTION
`bulkUpdate` already rejected direct root primary-key changes, but compound and nested inbound keys could still move. That could silently create a second record instead of updating the existing one.

This makes `bulkUpdate` apply the requested changes to a clone first, then compare the resulting inbound primary key with the original key. If the key changed, it now throws `ConstraintError`, matching the existing root primary-key behavior.

I added coverage for compound and nested primary-key changes. The TypeScript source build, TypeScript test build, browser bundle build, and headless Chrome Karma run all passed, with 308 tests completed.

Fixes #2218