### PR TITLE
fix(live-query): react on mutations of falsy but valid primary keys (issue #2021)

### DIFF
--- a/src/live-query/observability-middleware.ts
+++ b/src/live-query/observability-middleware.ts
@@ -79,7 +79,12 @@ export const observabilityMiddleware: Middleware<DBCore> = {
                   ? [req.keys] // keys known already here. newObjs will be undefined.
                   : req.values.length < 50
                     ? [
-                        getEffectiveKeys(primaryKey, req).filter((id) => id),
+                        // Filter out null/undefined keys only - they are the
+                        // autoIncremented ones. Falsy keys such as 0 and '' are
+                        // valid IndexedDB keys and must be kept (issue #2021).
+                        getEffectiveKeys(primaryKey, req).filter(
+                          (id) => id != null
+                        ),
                         req.values,
                       ] // keys except autoIncremented - they will be added later on.
                     : []; // keys and newObjs will both be undefined - changeSpec will become true (changed for entire table)

--- a/test/tests-live-query.js
+++ b/test/tests-live-query.js
@@ -920,3 +920,29 @@ promisedTest("Issue 2309: useLiveQuery stops updating when mutating returned obj
   }
 });
 
+promisedTest("Issue 2021: liveQuery must react on mutations of falsy but valid primary keys", async () => {
+  // Number 0 and empty string are falsy in javascript but perfectly valid IndexedDB keys.
+  for (const id of [0, ""]) {
+    const idStr = JSON.stringify(id);
+    await db.items.put({id, name: "before"});
+    const log = [];
+    let signal = new Signal();
+    const subscription = liveQuery(
+      () => db.items.where('id').equals(id).toArray()
+    ).subscribe(result => {
+      log.push(result);
+      signal.resolve(result);
+    });
+    await signal.promise;
+    deepEqual(log[0], [{id, name: "before"}], `Initial emit for primary key ${idStr}`);
+
+    signal = new Signal();
+    await db.items.update(id, {name: "after"});
+    await Promise.race([signal.promise, new Promise(resolve => setTimeout(resolve, 300))]);
+    equal(log.length, 2, `liveQuery re-emitted after updating the item with primary key ${idStr}`);
+    deepEqual(log[log.length - 1], [{id, name: "after"}], `Latest emit holds the updated value for primary key ${idStr}`);
+
+    subscription.unsubscribe();
+  }
+});
+


### PR DESCRIPTION
Fixes #2021.

`observabilityMiddleware.mutate()` filtered the effective primary keys of an add/put with `.filter((id) => id)`. That drops `0` and `''`, which are perfectly valid IndexedDB keys, so the mutation was recorded against an empty primary-key RangeSet and no live query subscribed to those keys was ever woken up. `table.update(0, {...})` wrote to IndexedDB but `useLiveQuery` never re-emitted; any other key worked.

The filter is only there to drop keys that haven't been assigned yet on an autoIncrement table. `getEffectiveKeys()` returns `req.keys || req.values.map(extractKey)`, and an unassigned inbound key extracts to `undefined`, so `!= null` is exactly the right test — a truthiness check additionally throws away legitimate falsy keys. `cache-middleware.ts` already asks the same question as `getEffectiveKeys(primKey, req).some((key) => key == null)`, and `hooks-middleware.ts` uses `key == null` too, so this also makes the three middlewares agree about the same request.

Nothing invalid slips through: `RangeSet.addRange()` already discards keys where `cmp()` returns NaN, which is how `trackAffectedIndexes()` in this same file has always handled it.

Added a regression test in `test/tests-live-query.js` covering both `0` and `''`. The query shape matters — it has to be a cachable `query` (`where('id').equals(id).toArray()`); a `get()`-based live query goes down the txcommit notification path and passes even without the fix.

Full suite green (308/308, Chrome headless) plus `test:typings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed live queries so updates to records with valid primary keys of `0` or an empty string are detected correctly.
  - Ensured related subscriptions receive accurate change notifications for these records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->