### PR TITLE
fix(dbcore): don't crash when an index is named 'constructor'

### DIFF
--- a/src/dbcore/virtual-index-middleware.ts
+++ b/src/dbcore/virtual-index-middleware.ts
@@ -46,7 +46,8 @@ export function createVirtualIndexMiddleware(down: DBCore): DBCore {
     table(tableName: string) {
       const table = down.table(tableName);
       const { schema } = table;
-      const indexLookup: { [indexAlias: string]: VirtualIndex[] } = {};
+      const indexLookup: { [indexAlias: string]: VirtualIndex[] } =
+        Object.create(null);
       const allVirtualIndexes: VirtualIndex[] = [];
 
       function addVirtualIndexes(

--- a/test/tests-misc.js
+++ b/test/tests-misc.js
@@ -535,3 +535,25 @@ promisedTest("Issue #1890 - BigInt64Array getting corrupted after an update", as
     val = await db.foo.get(1);
     ok(val.cols[0].values instanceof BigInt64Array, "cols[0].values is still a BigInt64Array after update");
 });
+
+promisedTest("Issue #1920 - table with an index or primary key named 'constructor' should not crash db.open()", async () => {
+    const dbName = "TestIssue1920";
+    await Dexie.delete(dbName);
+    const idb = new Dexie(dbName);
+    idb.version(1).stores({
+        items: "id, constructor"
+    });
+    try {
+        await idb.open();
+        ok(true, "db.open() succeeded with a 'constructor'-named index");
+
+        await idb.items.add({ id: 1, constructor: "foo" });
+        const result = await idb.items.where("constructor").equals("foo").first();
+        ok(result && result.id === 1, "Could add and query a row using the 'constructor' index");
+    } catch (error) {
+        ok(false, "db.open() (or subsequent use of the 'constructor' index) should not throw, but threw: " + error);
+    } finally {
+        idb.close();
+        await Dexie.delete(dbName);
+    }
+});


### PR DESCRIPTION
## What

Declaring a table whose primary key or an index is named `constructor` crashes `db.open()`:

```js
db.version(1).stores({ items: 'id, constructor' });
await db.open(); // TypeError: indexList.push is not a function
```

## Why

In `src/dbcore/virtual-index-middleware.ts`, `indexLookup` is a plain object literal used as a string-keyed map:

```ts
const indexLookup: { [indexAlias: string]: VirtualIndex[] } = {};
// ...
const indexList = (indexLookup[keyPathAlias] = indexLookup[keyPathAlias] || []);
indexList.push(virtualIndex);
```

When an index's key-path alias is `constructor`, `indexLookup['constructor']` resolves through `Object.prototype` to the inherited `Object` constructor (truthy, non-array), so the `|| []` fallback never runs and `.push()` is called on a function. This affects any index name that collides with an `Object.prototype` member (`constructor`, `toString`, `valueOf`, `hasOwnProperty`, …).

## Fix

Give `indexLookup` no prototype, so a bracket lookup can only ever resolve to an own key:

```ts
const indexLookup: { [indexAlias: string]: VirtualIndex[] } =
  Object.create(null);
```

All four `indexLookup` accesses are plain bracket get/set, so this is safe with no API change.

## Test

Adds a regression test in `test/tests-misc.js` that opens a db with an index named `constructor`, inserts a row, and reads it back via `where('constructor').equals(...)` — failing before the change with `TypeError: indexList.push is not a function` and passing after.

Fixes #1920.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database indexes named `constructor`, preventing errors during database operations.
  * Strengthened dictionary-based index lookups to avoid conflicts with inherited object properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->