### PR TITLE
fix(dexie-cloud-addon): fall back to fetchTokens when refresh fails

### DIFF
--- a/addons/dexie-cloud/src/authentication/login.ts
+++ b/addons/dexie-cloud/src/authentication/login.ts
@@ -27,11 +27,27 @@ export async function login(db: DexieCloudDB, hints?: LoginHints) {
       (!currentUser.refreshTokenExpiration ||
         currentUser.refreshTokenExpiration.getTime() > Date.now())
     ) {
-      // Refresh the token
-      await loadAccessToken(db);
-      return false;
+      // Refresh the token. This can fail not just from network errors but
+      // also because the server has permanently invalidated the refresh
+      // token itself (e.g. the issuing API client was revoked or rotated --
+      // see client_id claim checked on the 'refresh_token' grant). A locally
+      // unexpired refreshTokenExpiration does NOT guarantee the server still
+      // honors the token. In that case, don't throw: fall through to the
+      // same re-authentication path used below for "no refresh token",
+      // which re-runs fetchTokens exactly as on first login. Callers with
+      // their own fetchTokens (e.g. impersonation-based custom auth) can
+      // either silently re-mint tokens under the hood if their own session
+      // is still valid, or trigger their own challenge/login flow if not --
+      // same as a first-time login would.
+      try {
+        await loadAccessToken(db);
+        return false;
+      } catch (err) {
+        if (err?.name === 'OAuthRedirectError') throw err; // Page is navigating away
+        // Fall through to re-authenticate below.
+      }
     }
-    // No refresh token - must re-authenticate:
+    // No refresh token (or refresh failed) - must re-authenticate:
   }
   const context = new AuthPersistedContext(db, {
     claims: {},


### PR DESCRIPTION
## Why

Server-side, refresh tokens issued via the `client_credentials` grant (impersonation) now carry a `client_id` claim and get checked against that exact `internal.clients` row on every `refresh_token` grant exchange — see [dexie/dexie-cloud#195](https://github.com/dexie/dexie-cloud/pull/195). This means a revoked or expired (`expires_at`) API client's refresh tokens correctly stop working, even though the refresh token's own `exp` claim can be up to 3650 days out.

Client-side, `login()` had no recovery path for that case: a locally unexpired `refreshTokenExpiration` was trusted blindly, and `loadAccessToken()` throwing on a 401 propagated straight out of `login()` uncaught.

This matters most for customers using their own `fetchTokens` config (e.g. a backend that impersonates end-users via `client_credentials` + `claims`). If their backend's own API client is later rotated (`dexie-cloud rotate`) or expires, all of that customer's end-users would previously get an uncaught error on next refresh, with no built-in recovery.

## What changed

In `login()`, a refresh failure (other than an `OAuthRedirectError`, which means the page is navigating away) now falls through to the exact same re-authentication path already used for the "no refresh token" case — re-running `fetchTokens` exactly as on first login, instead of throwing.

Practical effect for customers with custom `fetchTokens`: this becomes self-healing. Their endpoint can either silently re-mint tokens under the hood (if their own session/auth is still valid), or trigger their own challenge/login flow (if not) — same UX as a first-time login.

## Testing

- `pnpm build` — clean.
- No existing unit test coverage for `login()`/the auth flow in this addon's karma suite (only `max-unsynced-mutations` exists today) — verified via manual trace of the control flow instead. Noting this explicitly rather than claiming test coverage that doesn't exist.
- CodeRabbit: 0 findings.

## Related

- Server-side change this depends on: dexie/dexie-cloud#195 (adds `client_id` claim + refresh-token revocation check + `dexie-cloud rotate`). Recommend releasing together, or at minimum this addon fix before/alongside the server release, so the new server-side enforcement doesn't strand existing custom-auth integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in recovery when a saved session token is missing or fails.
  * Users are now guided through full authentication when session renewal cannot be completed.
  * OAuth redirect errors continue to be handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->